### PR TITLE
Feature/met mast reader

### DIFF
--- a/dataloaders.py
+++ b/dataloaders.py
@@ -43,7 +43,7 @@ def read_dir(dpath='.',file_filter='*',
         if verbose:
             print('Reading '+fpath)
         try:
-            df = reader(fpath,**kwargs)
+            df = reader(fpath,verbose=verbose,**kwargs)
         except reader_exceptions as err:
             print(err,'while reading',fpath)
         dataframes.append(df)
@@ -95,7 +95,7 @@ def read_date_dirs(dpath='.',dir_filter='*',
                     if verbose:
                         print('  reading '+fname)
                     try:
-                        df = reader(fpath,**kwargs)
+                        df = reader(fpath,verbose=verbose,**kwargs)
                     except reader_exceptions as err:
                         print('Reader error {:s}: {:s} while reading {:s}'.format(
                                 str(type(err)),str(err),fname))

--- a/measurements/metmast.py
+++ b/measurements/metmast.py
@@ -8,9 +8,7 @@ from collections import OrderedDict
 import numpy as np
 import pandas as pd
 
-#
 # TODO:
-# - standardize names ("wspd" vs "windspeed" vs "speed", etc)
 # - standardize units
 # - standardize quantities (air temperature vs virtual temperature etc)
 
@@ -21,7 +19,14 @@ height_name = 'height'
 windspeed_name = 'wspd'
 winddirection_name = 'wdir'
 
-#
+standard_output_columns = [
+    datetime_name,
+    height_name,
+    windspeed_name,
+    winddirection_name
+]
+
+
 # Data descriptors
 # ================
 # Use OrderedDict to correctly associate columns with data. Data columns
@@ -63,6 +68,7 @@ Gill_R3_50 = OrderedDict(
     Ts=lambda Ts: 273.15 + Ts, # virtual sonic temperature [deg C]
     qc=1, # basic quality control code: 0 - OK, 1 - sonic bad data code, 2 - broken data line, and 3 - missed line
 )
+
 
 def read_data(fpath, column_spec,
               height=None, multi_index=False,

--- a/measurements/metmast.py
+++ b/measurements/metmast.py
@@ -233,8 +233,8 @@ def read_data(fpath, column_spec,
 
     # standard calculations
     if not windspeed_name in column_spec.keys():
-        # assume we have all velocity components
-        df[windspeed_name] = np.sqrt(df['u']**2 + df['v']**2 + df['w']**2)
+        # assume we have u,v velocity components
+        df[windspeed_name] = np.sqrt(df['u']**2 + df['v']**2)
     if not winddirection_name in column_spec.keys():
         # assume we have u,v velocity components
         df[winddirection_name] = np.degrees(np.arctan2(-df['u'],-df['v']))

--- a/measurements/metmast.py
+++ b/measurements/metmast.py
@@ -134,7 +134,7 @@ def read_data(fpath, column_spec,
         else:
             raise TypeError('Unexpected column name/format:',(col,fmt))
     if (len(datetime_columns) == 0) and \
-            ((datetime is None) or ((datetime_start is None) and (data_freq is None))):
+            ((datetime is None) and ((datetime_start is None) or (data_freq is None))):
         raise ValueError('No datetime data in file; need to specify datetime, or datetime_start and data_freq')
     elif (len(datetime_columns) > 0) and (datetime is not None):
         print('Note: datetime specified; datetime information in datafile ignored')

--- a/measurements/metmast.py
+++ b/measurements/metmast.py
@@ -64,6 +64,27 @@ def read_data(fname, column_spec,
               **kwargs):
     """Read in data (e.g., output from a sonic anemometer) at a height
     on the met mast and standardize outputs
+
+    Inputs
+    ------
+    fname : str
+        Filename passed to pandas.read_csv()
+    column_spec : OrderedDict
+        Pairs of column names and data formats
+    height : float, optional
+        Height to associate with this data (column will be added)
+    multi_index : bool, optional
+        If height is specified, then return a pandas.DataFrame with a
+        MultiIndex
+    datetime_start : str, optional
+        To specify datetime information missing from the data file
+    datetime_start_format : str, optional
+        If datetime_start is specified, then the format of the provided
+        datetime string
+    start,end : str or datetime, optional
+        Trim the data down to this specified time range
+    **kwargs : optional
+        Additional arguments to pass to pandas.read_csv()
     """
     columns = column_spec.keys()
     df = pd.read_csv(fname,names=columns,**kwargs)

--- a/measurements/metmast.py
+++ b/measurements/metmast.py
@@ -78,6 +78,7 @@ def read_data(fpath, column_spec,
               datetime=None, datetime_offset=None,
               start=pd.datetime(1990,1,1), end=pd.datetime.today(),
               return_description=False,
+              verbose=False,
               **kwargs):
     """Read in data (e.g., output from a sonic anemometer) at a height
     on the met mast and standardize outputs
@@ -157,10 +158,12 @@ def read_data(fpath, column_spec,
             ((datetime is None) and ((datetime_start is None) or (data_freq is None))):
         raise ValueError('No datetime data in file; need to specify datetime, or datetime_start and data_freq')
     elif (len(datetime_columns) > 0) and (datetime is not None):
-        print('Note: datetime specified; datetime information in datafile ignored')
+        if verbose:
+            print('Note: datetime specified; datetime information in datafile ignored')
     elif (len(datetime_columns) > 0) and \
             (datetime_start is not None) and (data_freq is not None):
-        print('Note: datetime_start and data_freq specified; datetime information in datafile ignored')
+        if verbose:
+            print('Note: datetime_start and data_freq specified; datetime information in datafile ignored')
 
     if callable(datetime_start):
         # parse datetime from file name
@@ -187,7 +190,7 @@ def read_data(fpath, column_spec,
     elif (date_name in datetime_columns) and (time_name in datetime_columns):
         # we have separate date and time columns
         if datetime_start is not None:
-            print('Ignored specified datetime_start')
+            if verbose: print('Ignored specified datetime_start')
         date_format = column_spec[date_name]
         time_format = column_spec[time_name]
         df[datetime_name] = pd.to_datetime(df[date_name]+df[time_name],

--- a/measurements/metmast.py
+++ b/measurements/metmast.py
@@ -61,6 +61,7 @@ Gill_R3_50 = OrderedDict(
     u=1, # East-West, plus to East
     w=1, # Vertical, plus upward
     Ts=lambda Ts: 273.15 + Ts, # virtual sonic temperature [deg C]
+    qc=1, # basic quality control code: 0 - OK, 1 - sonic bad data code, 2 - broken data line, and 3 - missed line
 )
 
 def read_data(fpath, column_spec,

--- a/measurements/metmast.py
+++ b/measurements/metmast.py
@@ -132,7 +132,7 @@ def read_data(fname, column_spec,
             raise TypeError('Unexpected column name/format:',(col,fmt))
     if (len(datetime_columns) == 0) and \
             ((datetime is None) or ((datetime_start is None) and (data_freq is None))):
-        raise InputError('No datetime data in file; need to specify datetime, or datetime_start and data_freq')
+        raise ValueError('No datetime data in file; need to specify datetime, or datetime_start and data_freq')
     elif (len(datetime_columns) > 0) and (datetime is not None):
         print('Note: datetime specified; datetime information in datafile ignored')
     elif (len(datetime_columns) > 0) and \

--- a/measurements/metmast.py
+++ b/measurements/metmast.py
@@ -34,7 +34,7 @@ Metek_USA1 = OrderedDict(
     v=100, # units are cm/s, i.e., 100*[m/s]
     u=100, 
     w=100,
-    T=lambda Ts: 273.15 + Ts/100, # sonic temperature, 100*[deg C]
+    Ts=lambda Ts: 273.15 + Ts/100, # sonic temperature, 100*[deg C]
     time='%H:%M:%S',
 )
 
@@ -55,6 +55,12 @@ RMYoung_05106 = OrderedDict(
     p10X=1, # datalogger power [V]
 )
 
+Gill_R3_50 = OrderedDict(
+    v=1, # North-South, plus to North
+    u=1, # East-West, plus to East
+    w=1, # Vertical, plus upward
+    Ts=lambda Ts: 273.15 + Ts, # virtual sonic temperature [deg C]
+)
 
 def read_data(fname, column_spec,
               height=None, multi_index=False,

--- a/measurements/metmast.py
+++ b/measurements/metmast.py
@@ -122,9 +122,14 @@ def read_data(fname, column_spec,
             raise TypeError('Unexpected column name/format:',(col,fmt))
     if (len(datetime_columns) == 0) and (datetime is None):
         raise InputError('No datetime data in file; need to specify datetime')
+    elif (len(datetime_columns) > 0) and (datetime is not None):
+        print('Note: datetime specified; datetime information in datafile ignored')
 
     # set up date/time column
-    if datetime_name in datetime_columns:
+    if datetime is not None:
+        # use user-specified datetime
+        df[datetime_name] = datetime
+    elif datetime_name in datetime_columns:
         # we have complete information
         datetime_format = column_spec[datetime_name]
         df[datetime_name] = pd.to_datetime(df[datetime_name],
@@ -137,9 +142,6 @@ def read_data(fname, column_spec,
         time_format = column_spec[time_name]
         df[datetime_name] = pd.to_datetime(df[date_name]+df[time_name],
                                            format=date_format+time_format)
-    elif datetime is not None:
-        # use user-specified datetime
-        df[datetime_name] = datetime
     else:
         # try to cobble together datetime information from all text columns
         # - convert datetime columns into string type (so that we can add them

--- a/measurements/metmast.py
+++ b/measurements/metmast.py
@@ -91,13 +91,13 @@ def read_data(fpath, column_spec,
     datetime_start_format : str, optional
         If datetime_start is specified, then the format of the provided
         datetime string
-    datetime : pandas.DateTimeIndex, optional
+    datetime : pandas.DatetimeIndex, optional
         If no date or time information are included in datafile, use
         this specified datetime series
     data_freq : str, optional
         Assuming data were recorded at regular intervals, the time
         between samples described by a pandas offset string; used with
-        datetime_start to create a DateTimeIndex when no date or time
+        datetime_start to create a DatetimeIndex when no date or time
         information are included in the datafile
     datetime_offset : float, optional
         Add a time offset (in seconds) that will be converted into a
@@ -158,7 +158,7 @@ def read_data(fpath, column_spec,
         datetime_start = pd.to_datetime(datetime_start,
                                         format=datetime_start_format)
         df[datetime_name] = pd.DatetimeIndex(start=datetime_start,
-                                             freq=data_freq)
+                                             periods=len(df), freq=data_freq)
     elif datetime_name in datetime_columns:
         # we have complete information
         datetime_format = column_spec[datetime_name]

--- a/measurements/metmast.py
+++ b/measurements/metmast.py
@@ -239,6 +239,25 @@ def read_data(fpath, column_spec,
         # assume we have u,v velocity components
         df[winddirection_name] = np.degrees(np.arctan2(-df['u'],-df['v']))
         df.loc[df[winddirection_name] < 0, winddirection_name] += 360.0
+    try:
+        # drop "nonstandard" variables
+        df = df.drop(columns=['u','v'])
+    except KeyError: pass
 
     return df
+
+def standard_output(df):
+    """Proposed workflow for "step 1", which entails reading, combining,
+    and standardizing data prior to analysis:
+        df = read_data()
+        df['calculated_data'] = some_postprocessing()
+        standard_output(df).to_csv()
+        standard_output(df).to_xarray().to_netcdf()
+    """
+    output_columns = [datetime_name,height_name,windspeed_name,winddirection_name]
+    column_list = list(df.columns)
+    for col in output_columns: 
+        column_list.remove(col)
+    output_columns += column_list
+    return df[column_list]
 

--- a/measurements/metmast.py
+++ b/measurements/metmast.py
@@ -3,6 +3,112 @@ Data readers for meteorological towers
 
 Based on https://github.com/NWTC/datatools/blob/master/metmast.py
 """
+from collections import OrderedDict
 import numpy as np
 import pandas as pd
+
+#
+# TODO:
+# - standardize names ("wspd" vs "windspeed" vs "speed", etc)
+# - standardize units
+# - standardize quantities (air temperature vs virtual temperature etc)
+
+datetime_name = 'datetime'
+date_name = 'date' # for building datetime from separate columns
+time_name = 'time' # for building datetime from separate columns
+height_name = 'height'
+windspeed_name = 'wspd'
+winddirection_name = 'wdir'
+
+#
+# Data descriptors
+# ================
+# Use OrderedDict to correctly associate columns with data. Data columns
+# are identified as follows:
+# - float: scaling factor applied to get the data units (default is 1)
+# - callable: function to convert from data to standardized data
+# - str: datetime format
+# - None: ignore column
+
+Metek_USA1 = OrderedDict(
+    v=100, # units are cm/s, i.e., 100*[m/s]
+    u=100, 
+    w=100,
+    T=lambda Ts: 273.15 + Ts/100, # sonic temperature, 100*[deg C]
+    time='%H:%M:%S',
+)
+
+RMYoung_05106 = OrderedDict(
+    ID=None,
+    year='%Y',  # 4-digit year
+    day='%j',  # julian day number
+    time='%H%M',
+    HorizontalWind=1, # mean horizontal wind speed
+    wspd=1,
+    wdir=1,
+    wdir_std=1,
+    T=lambda Ta: 273.15 + Ta, # air temperature [deg C]
+    RH=1,
+    P=lambda p: 1.0*p, # barometric pressure, not corrected for sea-level [mb]
+    SW_down=1,
+)
+
+
+def read_data(fname, column_spec,
+              height=None, multi_index=False,
+              datetime_offset=None,
+              start=pd.datetime(1990,1,1), end=pd.datetime.today(),
+              **kwargs):
+    """Read in data (e.g., output from a sonic anemometer) at a height
+    on the met mast and standardize outputs
+    """
+    df = pd.read_csv(fname)
+
+    # set up date/time column
+    if datetime_name in column_spec.keys():
+        # we have complete information
+        datetime_format = column_spec[datetime_name]
+        df[datetime_name] = pd.to_datetime(df[datetime_name],
+                                           format=datetime_format)
+        have_datetime = True
+    elif time_name in column_spec.keys():
+        # we have time (and optionally, date) information in separate columns
+        time_format = column_spec[time_name]
+        time = pd.to_timedelta(df[time_name], format=time_format)
+        if date_name in column_spec.keys():
+            assert(datetime_offset is None)
+            date_format = column_spec[date_name]
+            date = pd.to_datetime(df[date_name], format=date_format)
+            df[datetime_name] = date + time
+        elif datetime_offset is not None:
+            df[datetime_name] = datetime_offset + time
+            have_datetime = True
+        else:
+            print('Specify datetime_offset for complete datetime')
+            df[datetime_name] = time
+            have_datetime = False
+    else:
+        print('No datetime in column spec')
+
+    # trim datetime
+    if have_datetime:
+        datetime_range = (df[datetime_name] >= start) & (df[datetime_name] <= end)
+        df = df.loc[datetime_range]
+
+    # set height column (and multi-index)
+    if height is not None:
+        df[height_name] = height
+    if height and multi_index:
+        df = df.set_index([datetime_name,height_name])
+    else:
+        df = df.set_index(datetime_name)
+
+    # standard calculations
+    if not windspeed_name in column_spec.keys():
+        # assume we have all velocity components
+        df[windspeed_name] = np.sqrt(df['u']**2 + df['v']**2 + df['w']**2)
+    if not winddirection_name in column_spec.keys():
+        # assume we have u,v velocity components
+        df[winddirection_name] = np.degrees(np.arctan2(-df['u'],-df['v']))
+        df.loc[df[winddirection_name] < 0, winddirection_name] += 360.0
 

--- a/measurements/metmast.py
+++ b/measurements/metmast.py
@@ -81,6 +81,10 @@ def read_data(fname, column_spec,
     datetime_start_format : str, optional
         If datetime_start is specified, then the format of the provided
         datetime string
+    datetime_offset : float, optional
+        Add a time offset (in seconds) that will be converted into a
+        timedelta, e.g., for standardizing data that were averaged to
+        the beginning or end of an interval
     start,end : str or datetime, optional
         Trim the data down to this specified time range
     **kwargs : optional
@@ -155,7 +159,7 @@ def read_data(fname, column_spec,
     # add time offset, e.g., for standardizing data that were averaged to the
     # beginning/end of an interval
     if datetime_offset is not None:
-        offset = pd.to_timedelta(datetime_offset)
+        offset = pd.to_timedelta(datetime_offset,unit='s')
         df[datetime_name] += offset
 
     # trim datetime

--- a/measurements/metmast.py
+++ b/measurements/metmast.py
@@ -43,14 +43,16 @@ RMYoung_05106 = OrderedDict(
     year='%Y',  # 4-digit year
     day='%j',  # julian day number
     time='%H%M',
-    HorizontalWind=1, # mean horizontal wind speed
-    wspd=1,
-    wdir=1,
-    wdir_std=1,
+    HorizontalWind=1, # mean horizontal wind speed [m/s]
+    wspd=1, # resultant mean wind speed [m/s]
+    wdir=1, # resultant mean of wind direction == arctan(Ueast/Unorth) [deg]
+    wdir_std=1, # stdev of wind direction [deg]
     T=lambda Ta: 273.15 + Ta, # air temperature [deg C]
-    RH=1,
-    P=lambda p: 1.0*p, # barometric pressure, not corrected for sea-level [mb]
-    SW_down=1,
+    RH=1, # relative humidity [%]
+    P=1, # barometric pressure (not corrected for sea level) [mb]
+    SW_down=1, # downwelling SW solar radiation (400-1100nm) [W/m^2]
+    T10X=1, # datalogger temperature [deg C]
+    p10X=1, # datalogger power [V]
 )
 
 

--- a/measurements/metmast.py
+++ b/measurements/metmast.py
@@ -67,7 +67,7 @@ Gill_R3_50 = OrderedDict(
 def read_data(fpath, column_spec,
               height=None, multi_index=False,
               datetime_start='', datetime_start_format='',
-              data_freq=None, output_freq=None,
+              data_freq=None, max_data_rows=None, output_freq=None,
               datetime=None, datetime_offset=None,
               start=pd.datetime(1990,1,1), end=pd.datetime.today(),
               **kwargs):
@@ -100,6 +100,8 @@ def read_data(fpath, column_spec,
         between samples described by a pandas offset string; used with
         datetime_start to create a DatetimeIndex when no date or time
         information are included in the datafile
+    max_data_rows : int, optional
+        Maximum rows to process from datafile
     datetime_offset : float, optional
         Add a time offset (in seconds) that will be converted into a
         timedelta, e.g., for standardizing data that were averaged to
@@ -203,6 +205,8 @@ def read_data(fpath, column_spec,
         df[datetime_name] = pd.to_datetime(datetime, format=datetime_format)
         df = df.drop(columns=datetime_columns)
 
+    if max_data_rows is not None:
+        df = df.iloc[:max_data_rows]
     if output_freq is not None:
         N = int(output_freq)
         df = df.iloc[::N,:]

--- a/measurements/metmast.py
+++ b/measurements/metmast.py
@@ -223,6 +223,9 @@ def read_data(fpath, column_spec,
         datetime_format = datetime_start_format \
                 + ''.join([column_spec[col] for col in datetime_columns])
         # - create datetime series
+        if verbose:
+            print('Attempting to parse datetime with format"{:s}"'.format(datetime_format))
+            print(datetime)
         df[datetime_name] = pd.to_datetime(datetime, format=datetime_format)
         df = df.drop(columns=datetime_columns)
 

--- a/measurements/metmast.py
+++ b/measurements/metmast.py
@@ -65,7 +65,7 @@ Gill_R3_50 = OrderedDict(
 def read_data(fname, column_spec,
               height=None, multi_index=False,
               datetime_start='', datetime_start_format='',
-              datetime_offset=None,
+              datetime=None, datetime_offset=None,
               start=pd.datetime(1990,1,1), end=pd.datetime.today(),
               **kwargs):
     """Read in data (e.g., output from a sonic anemometer) at a height
@@ -87,6 +87,9 @@ def read_data(fname, column_spec,
     datetime_start_format : str, optional
         If datetime_start is specified, then the format of the provided
         datetime string
+    datetime : pandas.DateTimeIndex, optional
+        If no date or time information are included in datafile, use
+        this specified datetime series
     datetime_offset : float, optional
         Add a time offset (in seconds) that will be converted into a
         timedelta, e.g., for standardizing data that were averaged to
@@ -117,6 +120,8 @@ def read_data(fname, column_spec,
             df = df.drop(columns=col)
         else:
             raise TypeError('Unexpected column name/format:',(col,fmt))
+    if (len(datetime_columns) == 0) and (datetime is None):
+        raise InputError('No datetime data in file; need to specify datetime')
 
     # set up date/time column
     if datetime_name in datetime_columns:
@@ -132,6 +137,9 @@ def read_data(fname, column_spec,
         time_format = column_spec[time_name]
         df[datetime_name] = pd.to_datetime(df[date_name]+df[time_name],
                                            format=date_format+time_format)
+    elif datetime is not None:
+        # use user-specified datetime
+        df[datetime_name] = datetime
     else:
         # try to cobble together datetime information from all text columns
         # - convert datetime columns into string type (so that we can add them

--- a/measurements/metmast.py
+++ b/measurements/metmast.py
@@ -155,7 +155,8 @@ def read_data(fpath, column_spec,
         # use user-specified start datetime and time interval ('freq')
         # specified by a pandas offset string
         # ref: http://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#dateoffset-objects
-        datetime_start = pd.to_datetime(datetime_start)
+        datetime_start = pd.to_datetime(datetime_start,
+                                        format=datetime_start_format)
         df[datetime_name] = pd.DatetimeIndex(start=datetime_start,
                                              freq=data_freq)
     elif datetime_name in datetime_columns:

--- a/measurements/metmast.py
+++ b/measurements/metmast.py
@@ -89,8 +89,8 @@ def read_data(fpath, column_spec,
         Filename passed to pandas.read_csv()
     column_spec : OrderedDict
         Pairs of column names and data formats
-    height : float, optional
-        Height to associate with this data (column will be added)
+    height : float
+        Height to associate with this data
     multi_index : bool, optional
         If height is specified, then return a pandas.DataFrame with a
         MultiIndex
@@ -107,8 +107,9 @@ def read_data(fpath, column_spec,
     data_freq : str, optional
         Assuming data were recorded at regular intervals, the time
         between samples described by a pandas offset string; used with
-        datetime_start to create a DatetimeIndex when no date or time
-        information are included in the datafile
+        datetime_start to create a DatetimeIndex when date or time
+        information are not included in the datafile (or to overwrite
+        the data)
     max_data_rows : int, optional
         Maximum rows to process from datafile
     datetime_offset : float, optional
@@ -175,7 +176,7 @@ def read_data(fpath, column_spec,
         # use user-specified datetime
         df[datetime_name] = datetime
     elif datetime_start and data_freq:
-        # use user-specified start datetime and time interval ('freq')
+        # use user-specified start datetime and time interval ('data_freq')
         # specified by a pandas offset string
         # ref: http://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#dateoffset-objects
         datetime_start = pd.to_datetime(datetime_start,

--- a/measurements/metmast.py
+++ b/measurements/metmast.py
@@ -134,6 +134,10 @@ def read_data(fpath, column_spec,
         if fmt==1:
             #description.append('read column {:s}'.format(col))
             continue
+        elif isinstance(fmt,(int,float)):
+            # convert to standard units
+            description.append('scaled column {:s} by factor of {:g}'.format(col,1./fmt))
+            df[col] = df[col] / fmt
         elif callable(fmt):
             # apply function to column
             funcdesc = inspect.getsource(fmt)
@@ -141,10 +145,6 @@ def read_data(fpath, column_spec,
             funcdesc = funcdesc[eqidx+1:].strip()
             description.append('applied function ({:s}) to column {:s}'.format(funcdesc,col))
             df[col] = df[col].apply(fmt)
-        elif isinstance(fmt,float):
-            # convert to standard units
-            description.append('scaled column {:s} by factor of {:g}'.format(col,1./fmt))
-            df[col] = df[col] / fmt
         elif isinstance(fmt,str):
             # collect datetime column names
             #description.append('read datetime-related column {:s}'.format(col))


### PR DESCRIPTION
Generalized the `measurements/metmast` module to provide `read_data()` and `standard_output()`. As discussed on 3/21/19 with @amydecastro and @phawbeck , we will expect met data to include:
- 'datetime': in YYYY-MM-DD HH:MM:SS format
- 'height': height AGL [m]
- 'wspd': wind speed [m/s]
- 'wdir': compass wind direction, 0 is from the north [deg]
- [all other data columns, measured or derived]

@phawbeck will be happy to know that `standard_output()` supports both csv and netcdf. 