### PR TITLE
Temperature conversion utilities

### DIFF
--- a/helper_functions.py
+++ b/helper_functions.py
@@ -42,8 +42,6 @@ def T_d(T, RH, celsius=False, model='NWS'):
     """
     if model == 'NWS':
         es = e_s(T, celsius, model='NWS')
-        if not celsius:
-            T -= 273.15
         # from https://www.weather.gov/media/epz/wxcalc/virtualTemperature.pdf
         # - note the expression for vapor pressure is the saturation vapor
         #   pressure expression, with Td instead of T

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -4,7 +4,8 @@ Helper functions for calculating standard meteorological quantities
 import numpy as np
 import pandas as pd
 
-def T_to_Tv(T,p=None,RH=None,w=None,e=None,pd=None,epsilon=0.622,verbose=False):
+def T_to_Tv(T,p=None,RH=None,w=None,q=None,e=None,pd=None,
+            epsilon=0.622,verbose=False):
     """Convert moist air temperature [K] to virtual temperature [K].
     
     Formulas based on given total pressure (p, mbar) and relative
@@ -36,7 +37,7 @@ def T_to_Tv(T,p=None,RH=None,w=None,e=None,pd=None,epsilon=0.622,verbose=False):
         # alternative calculation, based on dewpoint
         if verbose:
             # from https://www.weather.gov/media/epz/wxcalc/virtualTemperature.pdf
-            # - note this is Wallace & Hobbs' eqn 3.16, also implemented  below
+            # - note this is Wallace & Hobbs' eqn 3.16, also implemented below
             # - note the expression for vapor pressure is similar to the
             #   saturation vapor pressure expression above, with Td instead of T
             # - is it 237.3 or 237.7?
@@ -50,6 +51,10 @@ def T_to_Tv(T,p=None,RH=None,w=None,e=None,pd=None,epsilon=0.622,verbose=False):
         if verbose:
             print('Tv(T,p,RH) ~=',T*(1+0.61*w))
         Tv = T * (w/epsilon + 1) / (1 + w)
+    elif q is not None:
+        w = q / (1-q)
+        # Using Wallace & Hobbs, Eqn 3.59
+        Tv = T * (w/epsilon + 1) / (1 + w)
     elif w is not None:
         # Using Wallace & Hobbs, Eqn 3.59
         Tv = T * (w/epsilon + 1) / (1 + w)
@@ -57,7 +62,7 @@ def T_to_Tv(T,p=None,RH=None,w=None,e=None,pd=None,epsilon=0.622,verbose=False):
         # Wallace & Hobbs, Eqn 3.16
         Tv = T / (1 - e/pd*(1-epsilon))
     else:
-        print('Specify (RH,) or (w,) or (e,pd)')
+        print('Specify (RH,p) or (q,) or (w,) or (e,pd)')
         Tv = None
     return Tv
 

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -1,0 +1,46 @@
+"""
+Helper functions for calculating standard meteorological quantities
+"""
+import numpy as np
+import pandas as pd
+
+def T_to_Tv(T,p=None,RH=None,w=None,e=None,pd=None,epsilon=0.622,verbose=False):
+    """Convert moist air temperature [K] to virtual temperature [K].
+    
+    Formulas based on given total pressure (p, mbar) and relative
+    humidity (RH, %); mixing ratio (w, kg/kg); or partial pressures of
+    water vapor and dry air (e, pd). Epsilon is the ratio of the gas
+    constants of dry air to water vapor.
+    """
+    if (p is not None) and (RH is not None):
+        # saturation vapor pressure of water, es [mbar]
+        #   Eqn 10 from Bolton (1980), Mon. Weather Rev., Vol 108
+        T_degC = T - 273.15
+        es = 6.112 * np.exp(17.67*T_degC / (T_degC + 243.5))
+        if verbose:
+            print('e_s(T) =',es)
+        # saturation mixing ratio, ws [-]
+        ws = epsilon * es / (p - es)
+        if verbose:
+            print('w_s(T,p) =',ws,'est',epsilon*es/p)
+        # mixing ratio, w, from definition of relative humidity
+        w = (RH/100.) * ws
+        # specific humidity, q (not needed at this point)
+        if verbose:
+            q = w / (1+w)
+            print('q(T,p,RH) =',q)
+        # Using Wallace & Hobbs, Eqn 3.59
+        if verbose:
+            print('Tv(T,p,RH) ~=',T*(1+0.61*w))
+        Tv = T * (w/epsilon + 1) / (1 + w)
+    elif w is not None:
+        # Using Wallace & Hobbs, Eqn 3.59
+        Tv = T * (w/epsilon + 1) / (1 + w)
+    elif (e is not None) and (pd is not None):
+        # Wallace & Hobbs, Eqn 3.16
+        Tv = T / (1 - e/pd*(1-epsilon))
+    else:
+        print('Specify (RH,) or (w,) or (e,pd)')
+        Tv = None
+    return Tv
+    

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -44,7 +44,7 @@ def T_d(T, RH, celsius=False, model='NWS'):
     are in Kelvin.
     """
     if model == 'NWS':
-        es = e_s(T, celsius, model='NWS')
+        es = e_s(T, celsius, model='Tetens')
         # From National Weather Service, using Tetens' formula:
         # https://www.weather.gov/media/epz/wxcalc/virtualTemperature.pdf
         # - note the expression for vapor pressure is the saturation vapor
@@ -119,7 +119,7 @@ def T_to_Tv(T,p=None,RH=None,e=None,w=None,Td=None,
         Td_degC = Td
         if not celsius:
             Td_degC -= 273.15
-        e_s(Td_degC, model='Tetens')
+        e = e_s(Td_degC, celsius=True, model='Tetens')
         # Calculate from definition of virtual temperature
         Tv = T_to_Tv(T,e=e,p=p)
     else:

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -60,4 +60,9 @@ def T_to_Tv(T,p=None,RH=None,w=None,e=None,pd=None,epsilon=0.622,verbose=False):
         print('Specify (RH,) or (w,) or (e,pd)')
         Tv = None
     return Tv
+
+
+def Ts_to_Tv(Ts,**kwargs):
+    """Convert sonic temperature [K] to virtual temperature [K].
+    """
     

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -4,25 +4,69 @@ Helper functions for calculating standard meteorological quantities
 import numpy as np
 import pandas as pd
 
-def T_to_Tv(T,p=None,RH=None,w=None,q=None,e=None,pd=None,
-            epsilon=0.622,verbose=False):
+
+# constants
+epsilon = 0.622 # ratio of molecular weights of water to dry air
+
+
+def e_s(T_degC, model='Bolton1980'):
+    """Calculate the saturation vapor pressure of water, $e_s$ [mbar]
+    given the air temperature in celsius.
+    """
+    if model == 'Bolton1980':
+        # Eqn 10 from Bolton (1980), Mon. Weather Rev., Vol 108
+        es = 6.112 * np.exp(17.67*T_degC / (T_degC + 243.5))
+    elif model == 'NWS':
+        # From National Weather Service
+        # https://www.weather.gov/media/epz/wxcalc/vaporPressure.pdf
+        # - where do these equations come from?
+        # - is it 237.3 or 237.7?
+        es = 6.11 * 10**(7.5*T_degC/(237.3+T_degC))
+    else:
+        raise ValueError('Unknown model: {:s}'.format(model))
+    return es
+
+
+def T_d(T, RH, model='NWS', celsius=False):
+    """Calculate the dewpoint temperature, $T_d$, from air temperature
+    and relative humidity [%]. If celsius is True, input and output 
+    temperatures are in degrees Celsius; otherwise, inputs and outputs
+    are in Kelvin.
+    """
+    if model == 'NWS':
+        if not celsius:
+            T -= 273.15
+        # from https://www.weather.gov/media/epz/wxcalc/virtualTemperature.pdf
+        # - note the expression for vapor pressure is the saturation vapor
+        #   pressure expression, with Td instead of T
+        # - should the coefficient be 237.3 or 237.7?
+        es = e_s(T, model='NWS')
+        e = RH/100. * es
+        denom = 7.5*np.log(10) - np.log(e/6.11)
+        Td = 237.3 * np.log(e/6.11) / denom
+        if not celsius:
+            Td += 273.15
+    else:
+        raise ValueError('Unknown model: {:s}'.format(model))
+    return Td
+
+
+def T_to_Tv(T,p=None,RH=None,e=None,w=None,Td=None,
+            verbose=False):
     """Convert moist air temperature [K] to virtual temperature [K].
     
-    Formulas based on given total pressure (p, mbar) and relative
-    humidity (RH, %); mixing ratio (w, kg/kg); or partial pressures of
-    water vapor and dry air (e, pd). Epsilon is the ratio of the gas
-    constants of dry air to water vapor.
+    Formulas based on given total (or "station") pressure (p [mbar]) and
+    relative humidity (RH [%]); mixing ratio (w [kg/kg]); or partial
+    pressures of water vapor and dry air (e, pd [mbar]); or dewpoint
+    temperature (Td [K]).
     """
     if (p is not None) and (RH is not None):
         # saturation vapor pressure of water, e_s [mbar]
-        #   Eqn 10 from Bolton (1980), Mon. Weather Rev., Vol 108
         T_degC = T - 273.15
-        es = 6.112 * np.exp(17.67*T_degC / (T_degC + 243.5))
+        es = e_s(T_degC)
         if verbose:
-            # from https://www.weather.gov/media/epz/wxcalc/vaporPressure.pdf
-            # - where do these equations come from?
-            # - is it 237.3 or 237.7?
-            es_est = 6.11 * 10**(7.5*T_degC/(237.3+T_degC))
+            # sanity check!
+            es_est = e_s(T_degC, model='NWS')
             print('e_s(T) =',es,'est',es_est)
         # saturation mixing ratio, ws [-]
         #   Wallace & Hobbs, Eqn 3.63
@@ -31,40 +75,33 @@ def T_to_Tv(T,p=None,RH=None,w=None,q=None,e=None,pd=None,
             print('w_s(T,p) =',ws,'est',epsilon*es/p)
         # mixing ratio, w, from definition of relative humidity
         w = (RH/100.) * ws
-        # specific humidity, q (not needed at this point)
         if verbose:
+            # we also have specific humidity, q, at this point (not needed)
             q = w / (1+w)
             print('q(T,p,RH) =',q)
-        # alternative calculation, based on dewpoint
-        if verbose:
-            # from https://www.weather.gov/media/epz/wxcalc/virtualTemperature.pdf
-            # - note this is Wallace & Hobbs' eqn 3.16, also implemented below
-            # - note the expression for vapor pressure is similar to the
-            #   saturation vapor pressure expression above, with Td instead of T
-            # - is it 237.3 or 237.7?
-            Td_degC = 237.3 * np.log(es*RH/611) / (7.5*np.log(10) - np.log(es*RH/611))
-            print('Td(T,RH) =',Td_degC)
-            e_est = 6.11 * 10**(7.5*Td_degC/(237.7+Td_degC))
-            denom = 1 - 0.379 * e_est/p
-            Tv_est = T / denom
-            print('est Tv(T,p,RH) =',Tv_est)
         # Using Wallace & Hobbs, Eqn 3.59
         if verbose:
+            # sanity check!
             print('Tv(T,p,RH) ~=',T*(1+0.61*w))
         Tv = T * (w/epsilon + 1) / (1 + w)
-    elif q is not None:
-        w = q / (1-q)
-        # Using Wallace & Hobbs, Eqn 3.59
-        Tv = T * (w/epsilon + 1) / (1 + w)
+    elif (e is not None) and (p is not None):
+        # Definition of virtual temperature
+        #   Wallace & Hobbs, Eqn 3.16
+        Tv = T / (1 - e/p*(1-epsilon))
     elif w is not None:
-        # Using Wallace & Hobbs, Eqn 3.59
+        # Using Wallace & Hobbs, Eqn 3.59 substituted into 3.16
         Tv = T * (w/epsilon + 1) / (1 + w)
-    elif (e is not None) and (pd is not None):
-        # Wallace & Hobbs, Eqn 3.16
-        Tv = T / (1 - e/pd*(1-epsilon))
+    elif (Td is not None) and (p is not None):
+        # From National Weather Service
+        # https://www.weather.gov/media/epz/wxcalc/vaporPressure.pdf
+        # - where do these equations come from?
+        # - is it 237.3 or 237.7?
+        Td_degC = Td - 273.15
+        e = 6.11 * 10**(7.5*Td_degC/(237.7+Td_degC))
+        # Calculate from definition of virtual temperature
+        Tv = T_to_Tv(T,e=e,p=p)
     else:
-        print('Specify (RH,p) or (q,) or (w,) or (e,pd)')
-        Tv = None
+        raise ValueError('Specify (RH,p) or (e,p) or (w,), or (Td,p)')
     return Tv
 
 

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -58,6 +58,15 @@ def T_d(T, RH, celsius=False, model='NWS'):
     return Td
 
 
+def w_s(T,p,celsius=False):
+    """Calculate the saturation mixing ratio, $w_s$ [kg/kg] given the
+    air temperature and station pressure [mb].
+    """
+    es = e_s(T,celsius)
+    # From Wallace & Hobbs, Eqn 3.63
+    return epsilon * es / (p - es)
+
+
 def T_to_Tv(T,p=None,RH=None,e=None,w=None,Td=None,
             verbose=False):
     """Convert moist air temperature [K] to virtual temperature [K].
@@ -76,8 +85,7 @@ def T_to_Tv(T,p=None,RH=None,e=None,w=None,Td=None,
             es_est = e_s(T_degC, model='NWS')
             print('e_s(T) =',es,'est',es_est)
         # saturation mixing ratio, ws [-]
-        #   Wallace & Hobbs, Eqn 3.63
-        ws = epsilon * es / (p - es)
+        ws = w_s(T, p)
         if verbose:
             print('w_s(T,p) =',ws,'est',epsilon*es/p)
         # mixing ratio, w, from definition of relative humidity

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -13,13 +13,17 @@ def T_to_Tv(T,p=None,RH=None,w=None,e=None,pd=None,epsilon=0.622,verbose=False):
     constants of dry air to water vapor.
     """
     if (p is not None) and (RH is not None):
-        # saturation vapor pressure of water, es [mbar]
+        # saturation vapor pressure of water, e_s [mbar]
         #   Eqn 10 from Bolton (1980), Mon. Weather Rev., Vol 108
         T_degC = T - 273.15
         es = 6.112 * np.exp(17.67*T_degC / (T_degC + 243.5))
         if verbose:
-            print('e_s(T) =',es)
+            # from https://www.weather.gov/media/epz/wxcalc/vaporPressure.pdf
+            # - is it 237.3 or 237.7?
+            es_est = 6.11 * 10**(7.5*T_degC/(237.3+T_degC))
+            print('e_s(T) =',es,'est',es_est)
         # saturation mixing ratio, ws [-]
+        #   Wallace & Hobbs, Eqn 3.63
         ws = epsilon * es / (p - es)
         if verbose:
             print('w_s(T,p) =',ws,'est',epsilon*es/p)
@@ -29,6 +33,19 @@ def T_to_Tv(T,p=None,RH=None,w=None,e=None,pd=None,epsilon=0.622,verbose=False):
         if verbose:
             q = w / (1+w)
             print('q(T,p,RH) =',q)
+        # alternative calculation, based on dewpoint
+        if verbose:
+            # from https://www.weather.gov/media/epz/wxcalc/virtualTemperature.pdf
+            # - note this is Wallace & Hobbs' eqn 3.16, also implemented  below
+            # - note the expression for vapor pressure is similar to the
+            #   saturation vapor pressure expression above, with Td instead of T
+            # - is it 237.3 or 237.7?
+            Td_degC = 237.3 * np.log(es*RH/611) / (7.5*np.log(10) - np.log(es*RH/611))
+            print('Td(T,RH) =',Td_degC)
+            e_est = 6.11 * 10**(7.5*Td_degC/(237.7+Td_degC))
+            denom = 1 - 0.379 * e_est/p
+            Tv_est = T / denom
+            print('est Tv(T,p,RH) =',Tv_est)
         # Using Wallace & Hobbs, Eqn 3.59
         if verbose:
             print('Tv(T,p,RH) ~=',T*(1+0.61*w))

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -123,7 +123,7 @@ def T_to_Tv(T,p=None,RH=None,e=None,w=None,Td=None,
         # Calculate from definition of virtual temperature
         Tv = T_to_Tv(T,e=e,p=p)
     else:
-        raise ValueError('Specify (RH,p) or (e,p) or (w,), or (Td,p)')
+        raise ValueError('Specify (T,RH,p) or (T,e,p) or (T,w), or (T,Td,p)')
     if celsius:
         Tv -= 273.15
     return Tv

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -24,6 +24,10 @@ def e_s(T, celsius=False, model='Tetens'):
         # Eqn 10 from Bolton (1980), Mon. Weather Rev., Vol 108
         # - applicable from -30 to 35 deg C
         svp = 6.112 * np.exp(17.67*T_degC / (T_degC + 243.5))
+    elif model == 'Magnus':
+        # Eqn 21 from Alduchov and Eskridge (1996), J. Appl. Meteorol., Vol 35
+        # - AERK formulation, applicable from -40 to 50 deg C
+        svp = 6.1094 * np.exp(17.625*T_degC / (243.04 + T_degC))
     elif model == 'Tetens':
         # Tetens' formula, e.g., from the National Weather Service:
         # https://www.weather.gov/media/epz/wxcalc/vaporPressure.pdf
@@ -84,6 +88,8 @@ def T_to_Tv(T,p=None,RH=None,e=None,w=None,Td=None,
         if verbose:
             # sanity check!
             es_est = e_s(T, model='Bolton')
+            print('e_s(T) =',es,'~=',es_est)
+            es_est = e_s(T, model='Magnus')
             print('e_s(T) =',es,'~=',es_est)
         # saturation mixing ratio, ws [-]
         ws = w_s(T, p)

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -41,13 +41,13 @@ def T_d(T, RH, celsius=False, model='NWS'):
     are in Kelvin.
     """
     if model == 'NWS':
+        es = e_s(T, celsius, model='NWS')
         if not celsius:
             T -= 273.15
         # from https://www.weather.gov/media/epz/wxcalc/virtualTemperature.pdf
         # - note the expression for vapor pressure is the saturation vapor
         #   pressure expression, with Td instead of T
         # - should the coefficient be 237.3 or 237.7?
-        es = e_s(T, model='NWS')
         e = RH/100. * es
         denom = 7.5*np.log(10) - np.log(e/6.11)
         Td = 237.3 * np.log(e/6.11) / denom

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -68,26 +68,30 @@ def w_s(T,p,celsius=False):
 
 
 def T_to_Tv(T,p=None,RH=None,e=None,w=None,Td=None,
-            verbose=False):
-    """Convert moist air temperature [K] to virtual temperature [K].
+            celsius=False,verbose=False):
+    """Convert moist air temperature to virtual temperature.
     
     Formulas based on given total (or "station") pressure (p [mbar]) and
     relative humidity (RH [%]); mixing ratio (w [kg/kg]); or partial
     pressures of water vapor and dry air (e, pd [mbar]); or dewpoint
-    temperature (Td [K]).
+    temperature (Td).
     """
+    if celsius:
+        T_degC = T
+        T += 273.15
+    else:
+        T_degC = T - 273.15
     if (p is not None) and (RH is not None):
         # saturation vapor pressure of water, e_s [mbar]
-        T_degC = T - 273.15
-        es = e_s(T_degC)
+        es = e_s(T)
         if verbose:
             # sanity check!
-            es_est = e_s(T_degC, model='NWS')
-            print('e_s(T) =',es,'est',es_est)
+            es_est = e_s(T, model='NWS')
+            print('e_s(T) =',es,'~=',es_est)
         # saturation mixing ratio, ws [-]
         ws = w_s(T, p)
         if verbose:
-            print('w_s(T,p) =',ws,'est',epsilon*es/p)
+            print('w_s(T,p) =',ws,'~=',epsilon*es/p)
         # mixing ratio, w, from definition of relative humidity
         w = (RH/100.) * ws
         if verbose:
@@ -111,12 +115,16 @@ def T_to_Tv(T,p=None,RH=None,e=None,w=None,Td=None,
         # https://www.weather.gov/media/epz/wxcalc/vaporPressure.pdf
         # - where do these equations come from?
         # - is it 237.3 or 237.7?
-        Td_degC = Td - 273.15
+        Td_degC = Td
+        if not celsius:
+            Td_degC -= 273.15
         e = 6.11 * 10**(7.5*Td_degC/(237.7+Td_degC))
         # Calculate from definition of virtual temperature
         Tv = T_to_Tv(T,e=e,p=p)
     else:
         raise ValueError('Specify (RH,p) or (e,p) or (w,), or (Td,p)')
+    if celsius:
+        Tv -= 273.15
     return Tv
 
 

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -20,6 +20,7 @@ def T_to_Tv(T,p=None,RH=None,w=None,q=None,e=None,pd=None,
         es = 6.112 * np.exp(17.67*T_degC / (T_degC + 243.5))
         if verbose:
             # from https://www.weather.gov/media/epz/wxcalc/vaporPressure.pdf
+            # - where do these equations come from?
             # - is it 237.3 or 237.7?
             es_est = 6.11 * 10**(7.5*T_degC/(237.3+T_degC))
             print('e_s(T) =',es,'est',es_est)
@@ -68,13 +69,15 @@ def T_to_Tv(T,p=None,RH=None,w=None,q=None,e=None,pd=None,
 
 
 def Ts_to_Tv(Ts,**kwargs):
-    """Convert sonic temperature [K] to virtual temperature [K].
+    """TODO: Convert sonic temperature [K] to virtual temperature [K].
     """
     
 
 def covariance(a,b,interval):
-    """Calculate covariance between two quantities in the specified
-    interval.
+    """Calculate covariance between two series (with datetime index) in
+    the specified interval, where the interval is defined by a pandas
+    offset string
+    (http://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#dateoffset-objects).
 
     Example:
         heatflux = covariance(df['Ts'],df['w'],'10min')
@@ -83,3 +86,4 @@ def covariance(a,b,interval):
     b_mean = b.rolling(interval).mean()
     ab_mean = (a*b).rolling(interval).mean()
     return ab_mean - a_mean*b_mean
+

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -9,10 +9,17 @@ import pandas as pd
 epsilon = 0.622 # ratio of molecular weights of water to dry air
 
 
-def e_s(T_degC, model='Bolton1980'):
-    """Calculate the saturation vapor pressure of water, $e_s$ [mbar]
-    given the air temperature in celsius.
+def e_s(T, celsius=False, model='Bolton1980'):
+    """Calculate the saturation vapor pressure of water, $e_s$ [mb]
+    given the air temperature.
     """
+    if celsius:
+        # input is deg C
+        T_degC = T
+        T = T + 273.15
+    else:
+        # input is in Kelvin
+        T_degC = T - 273.15
     if model == 'Bolton1980':
         # Eqn 10 from Bolton (1980), Mon. Weather Rev., Vol 108
         es = 6.112 * np.exp(17.67*T_degC / (T_degC + 243.5))
@@ -27,7 +34,7 @@ def e_s(T_degC, model='Bolton1980'):
     return es
 
 
-def T_d(T, RH, model='NWS', celsius=False):
+def T_d(T, RH, celsius=False, model='NWS'):
     """Calculate the dewpoint temperature, $T_d$, from air temperature
     and relative humidity [%]. If celsius is True, input and output 
     temperatures are in degrees Celsius; otherwise, inputs and outputs

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -71,3 +71,15 @@ def Ts_to_Tv(Ts,**kwargs):
     """Convert sonic temperature [K] to virtual temperature [K].
     """
     
+
+def covariance(a,b,interval):
+    """Calculate covariance between two quantities in the specified
+    interval.
+
+    Example:
+        heatflux = covariance(df['Ts'],df['w'],'10min')
+    """
+    a_mean = a.rolling(interval).mean()
+    b_mean = b.rolling(interval).mean()
+    ab_mean = (a*b).rolling(interval).mean()
+    return ab_mean - a_mean*b_mean

--- a/tests/T_to_Tv_tests.ipynb
+++ b/tests/T_to_Tv_tests.ipynb
@@ -628,7 +628,7 @@
    "metadata": {},
    "source": [
     "## Temperature/pressure conversions\n",
-    "As an exmaple, pick an arbitrary set of hourly mean values"
+    "As an example, pick an arbitrary set of hourly mean values"
    ]
   },
   {
@@ -920,8 +920,8 @@
     }
    ],
    "source": [
-    "test = hr_mean.loc['2016-11-21 23:00']\n",
-    "test[['T','RH','P']]"
+    "testdata = hr_mean.loc['2016-11-21 23:00']\n",
+    "testdata[['T','RH','P']]"
    ]
   },
   {
@@ -940,7 +940,7 @@
     {
      "data": {
       "text/plain": [
-       "10.961379766199544"
+       "10.97058660841359"
       ]
      },
      "execution_count": 15,
@@ -949,7 +949,7 @@
     }
    ],
    "source": [
-    "fun.e_s(test['T'],model='Bolton1980') # model='Bolton1980' (default)"
+    "fun.e_s(testdata['T'],model='Tetens') # Tetens' formula (default)"
    ]
   },
   {
@@ -960,7 +960,7 @@
     {
      "data": {
       "text/plain": [
-       "10.97058660841359"
+       "10.961379766199544"
       ]
      },
      "execution_count": 16,
@@ -969,14 +969,14 @@
     }
    ],
    "source": [
-    "fun.e_s(test['T'],model='NWS')"
+    "fun.e_s(testdata['T'],model='Bolton') # Bolton (1980), Mon. Weather Rev., Vol 108"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### dewpoint temperature <font color='orange'>- almost identical value</font>\n",
+    "### dewpoint temperature <font color='orange'>- nearly identical</font>\n",
     "https://www.weather.gov/epz/wxcalc_rh gives $T_d$ = 276.86 K (and wet-bulb temp = 279.22 K)"
    ]
   },
@@ -997,14 +997,14 @@
     }
    ],
    "source": [
-    "fun.T_d(test['T'],test['RH'])"
+    "fun.T_d(testdata['T'],testdata['RH'])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### mixing ratio <font color='green'>- PASSED</font>\n",
+    "### mixing ratio <font color='orange'>- nearly identical</font>\n",
     "https://www.weather.gov/epz/wxcalc_mixingratio gives $w_s$ = 7.17 g/kg (= 0.00717 kg/kg)"
    ]
   },
@@ -1016,7 +1016,7 @@
     {
      "data": {
       "text/plain": [
-       "0.007174171373612398"
+       "0.007180266769687286"
       ]
      },
      "execution_count": 18,
@@ -1025,7 +1025,7 @@
     }
    ],
    "source": [
-    "fun.w_s(test['T'],test['P'])"
+    "fun.w_s(testdata['T'],testdata['P'])"
    ]
   },
   {
@@ -1036,7 +1036,7 @@
     {
      "data": {
       "text/plain": [
-       "0.0070923677376087246"
+       "0.007098324862722254"
       ]
      },
      "execution_count": 19,
@@ -1045,8 +1045,8 @@
     }
    ],
    "source": [
-    "# assuming p >> e_s, Wallace & Hobbs Eqn. 3.63\n",
-    "fun.epsilon * fun.e_s(test['T']) / test['P']"
+    "# sanity check, assuming p >> e_s (Wallace & Hobbs, Eqn. 3.63)\n",
+    "fun.epsilon * fun.e_s(testdata['T']) / testdata['P']"
    ]
   },
   {
@@ -1065,7 +1065,7 @@
     {
      "data": {
       "text/plain": [
-       "282.36242470550195"
+       "282.36317505413456"
       ]
      },
      "execution_count": 20,
@@ -1074,7 +1074,7 @@
     }
    ],
    "source": [
-    "fun.T_to_Tv(test['T'], p=test['P'], RH=test['RH'])"
+    "fun.T_to_Tv(testdata['T'], p=testdata['P'], RH=testdata['RH'])"
    ]
   },
   {
@@ -1085,7 +1085,7 @@
     {
      "data": {
       "text/plain": [
-       "282.36000747648336"
+       "282.3604000240343"
       ]
      },
      "execution_count": 21,
@@ -1094,8 +1094,8 @@
     }
    ],
    "source": [
-    "Td = fun.T_d(test['T'],test['RH'])\n",
-    "fun.T_to_Tv(test['T'], Td=Td, p=test['P'])"
+    "Td = fun.T_d(testdata['T'],testdata['RH'])\n",
+    "fun.T_to_Tv(testdata['T'], Td=Td, p=testdata['P'])"
    ]
   },
   {

--- a/tests/T_to_Tv_tests.ipynb
+++ b/tests/T_to_Tv_tests.ipynb
@@ -1,0 +1,1130 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mmctools.dataloaders import read_dir # for reading a series of data files\n",
+    "from mmctools.measurements import metmast # provides readers for metmast data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mmctools import helper_functions as fun"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Unit tests: virtual temperature conversion\n",
+    "sample data from WFIP2 Physics Site PS07 met station"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datadir = '/Users/equon/WFIP2/PS07/201611'\n",
+    "starttime = pd.to_datetime('2016-11-21 17:00')\n",
+    "endtime = pd.to_datetime('2016-11-22 04:00')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data I/O"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OrderedDict([('ID', None),\n",
+       "             ('year', '%Y'),\n",
+       "             ('day', '%j'),\n",
+       "             ('time', '%H%M'),\n",
+       "             ('HorizontalWind', 1),\n",
+       "             ('wspd', 1),\n",
+       "             ('wdir', 1),\n",
+       "             ('wdir_std', 1),\n",
+       "             ('T', <function mmctools.measurements.metmast.<lambda>(Ta)>),\n",
+       "             ('RH', 1),\n",
+       "             ('P', 1),\n",
+       "             ('SW_down', 1),\n",
+       "             ('T10X', 1),\n",
+       "             ('p10X', 1)])"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# sensor data format\n",
+    "metmast.RMYoung_05106"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Basic usage (with generic CSV reader):\n",
+    "\n",
+    "`df = read_dir(datadir)`\n",
+    "\n",
+    "Met data usage:\n",
+    "\n",
+    "`df = read_dir(datadir, reader=metmast.read_data, column_spec=metmast.RMYoung_05106)`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = read_dir(datadir, ext='txt',\n",
+    "              file_filter='*.2016112[12].*', # read 20161121 and 20161122 only\n",
+    "              reader=metmast.read_data, column_spec=metmast.RMYoung_05106,\n",
+    "              height=3.0, # measurement height\n",
+    "              datetime_offset=-60, # shift 60s to line up with begining of interval\n",
+    "              start=starttime, end=endtime)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>HorizontalWind</th>\n",
+       "      <th>wspd</th>\n",
+       "      <th>wdir</th>\n",
+       "      <th>wdir_std</th>\n",
+       "      <th>T</th>\n",
+       "      <th>RH</th>\n",
+       "      <th>P</th>\n",
+       "      <th>SW_down</th>\n",
+       "      <th>T10X</th>\n",
+       "      <th>p10X</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>datetime</th>\n",
+       "      <th>height</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 17:00:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>0.871</td>\n",
+       "      <td>0.858</td>\n",
+       "      <td>271.5</td>\n",
+       "      <td>9.780</td>\n",
+       "      <td>279.481</td>\n",
+       "      <td>84.2</td>\n",
+       "      <td>959.58</td>\n",
+       "      <td>255.8</td>\n",
+       "      <td>6.605</td>\n",
+       "      <td>14.17</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 17:01:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>1.076</td>\n",
+       "      <td>1.074</td>\n",
+       "      <td>264.6</td>\n",
+       "      <td>3.722</td>\n",
+       "      <td>279.509</td>\n",
+       "      <td>83.2</td>\n",
+       "      <td>959.51</td>\n",
+       "      <td>263.0</td>\n",
+       "      <td>6.665</td>\n",
+       "      <td>13.58</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 17:02:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>1.204</td>\n",
+       "      <td>1.192</td>\n",
+       "      <td>260.4</td>\n",
+       "      <td>7.930</td>\n",
+       "      <td>279.552</td>\n",
+       "      <td>83.0</td>\n",
+       "      <td>959.51</td>\n",
+       "      <td>264.6</td>\n",
+       "      <td>6.732</td>\n",
+       "      <td>13.37</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 17:03:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>1.093</td>\n",
+       "      <td>1.081</td>\n",
+       "      <td>274.8</td>\n",
+       "      <td>8.350</td>\n",
+       "      <td>279.622</td>\n",
+       "      <td>83.3</td>\n",
+       "      <td>959.56</td>\n",
+       "      <td>257.6</td>\n",
+       "      <td>6.839</td>\n",
+       "      <td>13.73</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 17:04:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>1.552</td>\n",
+       "      <td>1.545</td>\n",
+       "      <td>260.3</td>\n",
+       "      <td>5.421</td>\n",
+       "      <td>279.703</td>\n",
+       "      <td>83.5</td>\n",
+       "      <td>959.51</td>\n",
+       "      <td>268.8</td>\n",
+       "      <td>6.907</td>\n",
+       "      <td>13.69</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                            HorizontalWind   wspd   wdir  wdir_std        T  \\\n",
+       "datetime            height                                                    \n",
+       "2016-11-21 17:00:00 3.0              0.871  0.858  271.5     9.780  279.481   \n",
+       "2016-11-21 17:01:00 3.0              1.076  1.074  264.6     3.722  279.509   \n",
+       "2016-11-21 17:02:00 3.0              1.204  1.192  260.4     7.930  279.552   \n",
+       "2016-11-21 17:03:00 3.0              1.093  1.081  274.8     8.350  279.622   \n",
+       "2016-11-21 17:04:00 3.0              1.552  1.545  260.3     5.421  279.703   \n",
+       "\n",
+       "                              RH       P  SW_down   T10X   p10X  \n",
+       "datetime            height                                       \n",
+       "2016-11-21 17:00:00 3.0     84.2  959.58    255.8  6.605  14.17  \n",
+       "2016-11-21 17:01:00 3.0     83.2  959.51    263.0  6.665  13.58  \n",
+       "2016-11-21 17:02:00 3.0     83.0  959.51    264.6  6.732  13.37  \n",
+       "2016-11-21 17:03:00 3.0     83.3  959.56    257.6  6.839  13.73  \n",
+       "2016-11-21 17:04:00 3.0     83.5  959.51    268.8  6.907  13.69  "
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>HorizontalWind</th>\n",
+       "      <th>wspd</th>\n",
+       "      <th>wdir</th>\n",
+       "      <th>wdir_std</th>\n",
+       "      <th>T</th>\n",
+       "      <th>RH</th>\n",
+       "      <th>P</th>\n",
+       "      <th>SW_down</th>\n",
+       "      <th>T10X</th>\n",
+       "      <th>p10X</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>datetime</th>\n",
+       "      <th>height</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2016-11-22 03:56:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>1.249</td>\n",
+       "      <td>1.242</td>\n",
+       "      <td>212.7</td>\n",
+       "      <td>6.455</td>\n",
+       "      <td>277.065</td>\n",
+       "      <td>82.0</td>\n",
+       "      <td>963.77</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>3.701</td>\n",
+       "      <td>12.78</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-22 03:57:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>0.699</td>\n",
+       "      <td>0.688</td>\n",
+       "      <td>234.8</td>\n",
+       "      <td>10.360</td>\n",
+       "      <td>276.980</td>\n",
+       "      <td>80.3</td>\n",
+       "      <td>963.78</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>3.672</td>\n",
+       "      <td>12.78</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-22 03:58:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>1.215</td>\n",
+       "      <td>1.199</td>\n",
+       "      <td>240.3</td>\n",
+       "      <td>9.320</td>\n",
+       "      <td>276.835</td>\n",
+       "      <td>80.8</td>\n",
+       "      <td>963.73</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>3.648</td>\n",
+       "      <td>12.77</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-22 03:59:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>1.405</td>\n",
+       "      <td>1.395</td>\n",
+       "      <td>220.1</td>\n",
+       "      <td>6.738</td>\n",
+       "      <td>276.844</td>\n",
+       "      <td>82.2</td>\n",
+       "      <td>963.75</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>3.623</td>\n",
+       "      <td>12.78</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-22 04:00:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>1.545</td>\n",
+       "      <td>1.543</td>\n",
+       "      <td>207.2</td>\n",
+       "      <td>3.276</td>\n",
+       "      <td>276.976</td>\n",
+       "      <td>82.2</td>\n",
+       "      <td>963.75</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>3.598</td>\n",
+       "      <td>12.77</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                            HorizontalWind   wspd   wdir  wdir_std        T  \\\n",
+       "datetime            height                                                    \n",
+       "2016-11-22 03:56:00 3.0              1.249  1.242  212.7     6.455  277.065   \n",
+       "2016-11-22 03:57:00 3.0              0.699  0.688  234.8    10.360  276.980   \n",
+       "2016-11-22 03:58:00 3.0              1.215  1.199  240.3     9.320  276.835   \n",
+       "2016-11-22 03:59:00 3.0              1.405  1.395  220.1     6.738  276.844   \n",
+       "2016-11-22 04:00:00 3.0              1.545  1.543  207.2     3.276  276.976   \n",
+       "\n",
+       "                              RH       P  SW_down   T10X   p10X  \n",
+       "datetime            height                                       \n",
+       "2016-11-22 03:56:00 3.0     82.0  963.77      0.0  3.701  12.78  \n",
+       "2016-11-22 03:57:00 3.0     80.3  963.78      0.0  3.672  12.78  \n",
+       "2016-11-22 03:58:00 3.0     80.8  963.73      0.0  3.648  12.77  \n",
+       "2016-11-22 03:59:00 3.0     82.2  963.75      0.0  3.623  12.78  \n",
+       "2016-11-22 04:00:00 3.0     82.2  963.75      0.0  3.598  12.77  "
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.tail()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "At this point, units and column names have been standardized according to the sensor data format specification.\n",
+    "\n",
+    "Call `metmast.standard_output()` to reorder columns and (optionally) write output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>wspd</th>\n",
+       "      <th>wdir</th>\n",
+       "      <th>HorizontalWind</th>\n",
+       "      <th>wdir_std</th>\n",
+       "      <th>T</th>\n",
+       "      <th>RH</th>\n",
+       "      <th>P</th>\n",
+       "      <th>SW_down</th>\n",
+       "      <th>T10X</th>\n",
+       "      <th>p10X</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>datetime</th>\n",
+       "      <th>height</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 17:00:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>0.858</td>\n",
+       "      <td>271.5</td>\n",
+       "      <td>0.871</td>\n",
+       "      <td>9.780</td>\n",
+       "      <td>279.481</td>\n",
+       "      <td>84.2</td>\n",
+       "      <td>959.58</td>\n",
+       "      <td>255.8</td>\n",
+       "      <td>6.605</td>\n",
+       "      <td>14.17</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 17:01:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>1.074</td>\n",
+       "      <td>264.6</td>\n",
+       "      <td>1.076</td>\n",
+       "      <td>3.722</td>\n",
+       "      <td>279.509</td>\n",
+       "      <td>83.2</td>\n",
+       "      <td>959.51</td>\n",
+       "      <td>263.0</td>\n",
+       "      <td>6.665</td>\n",
+       "      <td>13.58</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 17:02:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>1.192</td>\n",
+       "      <td>260.4</td>\n",
+       "      <td>1.204</td>\n",
+       "      <td>7.930</td>\n",
+       "      <td>279.552</td>\n",
+       "      <td>83.0</td>\n",
+       "      <td>959.51</td>\n",
+       "      <td>264.6</td>\n",
+       "      <td>6.732</td>\n",
+       "      <td>13.37</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 17:03:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>1.081</td>\n",
+       "      <td>274.8</td>\n",
+       "      <td>1.093</td>\n",
+       "      <td>8.350</td>\n",
+       "      <td>279.622</td>\n",
+       "      <td>83.3</td>\n",
+       "      <td>959.56</td>\n",
+       "      <td>257.6</td>\n",
+       "      <td>6.839</td>\n",
+       "      <td>13.73</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 17:04:00</th>\n",
+       "      <th>3.0</th>\n",
+       "      <td>1.545</td>\n",
+       "      <td>260.3</td>\n",
+       "      <td>1.552</td>\n",
+       "      <td>5.421</td>\n",
+       "      <td>279.703</td>\n",
+       "      <td>83.5</td>\n",
+       "      <td>959.51</td>\n",
+       "      <td>268.8</td>\n",
+       "      <td>6.907</td>\n",
+       "      <td>13.69</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                             wspd   wdir  HorizontalWind  wdir_std        T  \\\n",
+       "datetime            height                                                    \n",
+       "2016-11-21 17:00:00 3.0     0.858  271.5           0.871     9.780  279.481   \n",
+       "2016-11-21 17:01:00 3.0     1.074  264.6           1.076     3.722  279.509   \n",
+       "2016-11-21 17:02:00 3.0     1.192  260.4           1.204     7.930  279.552   \n",
+       "2016-11-21 17:03:00 3.0     1.081  274.8           1.093     8.350  279.622   \n",
+       "2016-11-21 17:04:00 3.0     1.545  260.3           1.552     5.421  279.703   \n",
+       "\n",
+       "                              RH       P  SW_down   T10X   p10X  \n",
+       "datetime            height                                       \n",
+       "2016-11-21 17:00:00 3.0     84.2  959.58    255.8  6.605  14.17  \n",
+       "2016-11-21 17:01:00 3.0     83.2  959.51    263.0  6.665  13.58  \n",
+       "2016-11-21 17:02:00 3.0     83.0  959.51    264.6  6.732  13.37  \n",
+       "2016-11-21 17:03:00 3.0     83.3  959.56    257.6  6.839  13.73  \n",
+       "2016-11-21 17:04:00 3.0     83.5  959.51    268.8  6.907  13.69  "
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ps7 = metmast.standard_output(df)\n",
+    "ps7.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# write out standardized timeseries data in csv format\n",
+    "metmast.standard_output(df,'test.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# write out standardized timeseries data in netcdf format\n",
+    "metmast.standard_output(df,'test.nc')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Temperature/pressure conversions\n",
+    "As an exmaple, pick an arbitrary set of hourly mean values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>wspd</th>\n",
+       "      <th>wdir</th>\n",
+       "      <th>HorizontalWind</th>\n",
+       "      <th>wdir_std</th>\n",
+       "      <th>T</th>\n",
+       "      <th>RH</th>\n",
+       "      <th>P</th>\n",
+       "      <th>SW_down</th>\n",
+       "      <th>T10X</th>\n",
+       "      <th>p10X</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>datetime</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 17:00:00</th>\n",
+       "      <td>1.944483</td>\n",
+       "      <td>240.593333</td>\n",
+       "      <td>1.958867</td>\n",
+       "      <td>6.601150</td>\n",
+       "      <td>280.433667</td>\n",
+       "      <td>80.503333</td>\n",
+       "      <td>959.679833</td>\n",
+       "      <td>292.691667</td>\n",
+       "      <td>8.233717</td>\n",
+       "      <td>13.519167</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 18:00:00</th>\n",
+       "      <td>2.844367</td>\n",
+       "      <td>251.378333</td>\n",
+       "      <td>2.864533</td>\n",
+       "      <td>6.527967</td>\n",
+       "      <td>280.612000</td>\n",
+       "      <td>83.845000</td>\n",
+       "      <td>960.026000</td>\n",
+       "      <td>235.665000</td>\n",
+       "      <td>9.661167</td>\n",
+       "      <td>13.455833</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 19:00:00</th>\n",
+       "      <td>4.265933</td>\n",
+       "      <td>251.836667</td>\n",
+       "      <td>4.302117</td>\n",
+       "      <td>7.274217</td>\n",
+       "      <td>282.391000</td>\n",
+       "      <td>78.631667</td>\n",
+       "      <td>960.055167</td>\n",
+       "      <td>382.946667</td>\n",
+       "      <td>10.185167</td>\n",
+       "      <td>13.479667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 20:00:00</th>\n",
+       "      <td>5.820167</td>\n",
+       "      <td>255.511667</td>\n",
+       "      <td>5.859383</td>\n",
+       "      <td>6.527083</td>\n",
+       "      <td>282.636833</td>\n",
+       "      <td>77.340000</td>\n",
+       "      <td>960.099833</td>\n",
+       "      <td>342.491667</td>\n",
+       "      <td>11.307333</td>\n",
+       "      <td>13.521000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 21:00:00</th>\n",
+       "      <td>6.272000</td>\n",
+       "      <td>251.678333</td>\n",
+       "      <td>6.310000</td>\n",
+       "      <td>6.242950</td>\n",
+       "      <td>282.516333</td>\n",
+       "      <td>75.923333</td>\n",
+       "      <td>960.322667</td>\n",
+       "      <td>242.920500</td>\n",
+       "      <td>11.641833</td>\n",
+       "      <td>13.466667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 22:00:00</th>\n",
+       "      <td>6.104433</td>\n",
+       "      <td>254.995000</td>\n",
+       "      <td>6.141233</td>\n",
+       "      <td>6.223867</td>\n",
+       "      <td>282.975000</td>\n",
+       "      <td>70.868333</td>\n",
+       "      <td>960.645167</td>\n",
+       "      <td>231.143333</td>\n",
+       "      <td>11.465500</td>\n",
+       "      <td>13.476333</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-21 23:00:00</th>\n",
+       "      <td>5.343033</td>\n",
+       "      <td>257.641667</td>\n",
+       "      <td>5.366133</td>\n",
+       "      <td>5.240950</td>\n",
+       "      <td>281.474667</td>\n",
+       "      <td>72.718000</td>\n",
+       "      <td>961.312000</td>\n",
+       "      <td>68.300333</td>\n",
+       "      <td>11.219333</td>\n",
+       "      <td>13.331667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-22 00:00:00</th>\n",
+       "      <td>2.927500</td>\n",
+       "      <td>252.476667</td>\n",
+       "      <td>2.936183</td>\n",
+       "      <td>4.317467</td>\n",
+       "      <td>279.763983</td>\n",
+       "      <td>78.291667</td>\n",
+       "      <td>962.066667</td>\n",
+       "      <td>4.760350</td>\n",
+       "      <td>8.786167</td>\n",
+       "      <td>12.924167</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-22 01:00:00</th>\n",
+       "      <td>2.385250</td>\n",
+       "      <td>230.681667</td>\n",
+       "      <td>2.395933</td>\n",
+       "      <td>4.835133</td>\n",
+       "      <td>278.799167</td>\n",
+       "      <td>80.931667</td>\n",
+       "      <td>962.662333</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>6.896683</td>\n",
+       "      <td>12.847833</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-22 02:00:00</th>\n",
+       "      <td>2.688817</td>\n",
+       "      <td>234.703333</td>\n",
+       "      <td>2.693483</td>\n",
+       "      <td>3.079950</td>\n",
+       "      <td>278.030133</td>\n",
+       "      <td>83.405000</td>\n",
+       "      <td>963.125833</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>5.531783</td>\n",
+       "      <td>12.811333</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-22 03:00:00</th>\n",
+       "      <td>1.791483</td>\n",
+       "      <td>189.110000</td>\n",
+       "      <td>1.798300</td>\n",
+       "      <td>4.539783</td>\n",
+       "      <td>277.313650</td>\n",
+       "      <td>82.285000</td>\n",
+       "      <td>963.507333</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>4.243350</td>\n",
+       "      <td>12.785500</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2016-11-22 04:00:00</th>\n",
+       "      <td>1.543000</td>\n",
+       "      <td>207.200000</td>\n",
+       "      <td>1.545000</td>\n",
+       "      <td>3.276000</td>\n",
+       "      <td>276.976000</td>\n",
+       "      <td>82.200000</td>\n",
+       "      <td>963.750000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>3.598000</td>\n",
+       "      <td>12.770000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                         wspd        wdir  HorizontalWind  wdir_std  \\\n",
+       "datetime                                                              \n",
+       "2016-11-21 17:00:00  1.944483  240.593333        1.958867  6.601150   \n",
+       "2016-11-21 18:00:00  2.844367  251.378333        2.864533  6.527967   \n",
+       "2016-11-21 19:00:00  4.265933  251.836667        4.302117  7.274217   \n",
+       "2016-11-21 20:00:00  5.820167  255.511667        5.859383  6.527083   \n",
+       "2016-11-21 21:00:00  6.272000  251.678333        6.310000  6.242950   \n",
+       "2016-11-21 22:00:00  6.104433  254.995000        6.141233  6.223867   \n",
+       "2016-11-21 23:00:00  5.343033  257.641667        5.366133  5.240950   \n",
+       "2016-11-22 00:00:00  2.927500  252.476667        2.936183  4.317467   \n",
+       "2016-11-22 01:00:00  2.385250  230.681667        2.395933  4.835133   \n",
+       "2016-11-22 02:00:00  2.688817  234.703333        2.693483  3.079950   \n",
+       "2016-11-22 03:00:00  1.791483  189.110000        1.798300  4.539783   \n",
+       "2016-11-22 04:00:00  1.543000  207.200000        1.545000  3.276000   \n",
+       "\n",
+       "                              T         RH           P     SW_down       T10X  \\\n",
+       "datetime                                                                        \n",
+       "2016-11-21 17:00:00  280.433667  80.503333  959.679833  292.691667   8.233717   \n",
+       "2016-11-21 18:00:00  280.612000  83.845000  960.026000  235.665000   9.661167   \n",
+       "2016-11-21 19:00:00  282.391000  78.631667  960.055167  382.946667  10.185167   \n",
+       "2016-11-21 20:00:00  282.636833  77.340000  960.099833  342.491667  11.307333   \n",
+       "2016-11-21 21:00:00  282.516333  75.923333  960.322667  242.920500  11.641833   \n",
+       "2016-11-21 22:00:00  282.975000  70.868333  960.645167  231.143333  11.465500   \n",
+       "2016-11-21 23:00:00  281.474667  72.718000  961.312000   68.300333  11.219333   \n",
+       "2016-11-22 00:00:00  279.763983  78.291667  962.066667    4.760350   8.786167   \n",
+       "2016-11-22 01:00:00  278.799167  80.931667  962.662333    0.000000   6.896683   \n",
+       "2016-11-22 02:00:00  278.030133  83.405000  963.125833    0.000000   5.531783   \n",
+       "2016-11-22 03:00:00  277.313650  82.285000  963.507333    0.000000   4.243350   \n",
+       "2016-11-22 04:00:00  276.976000  82.200000  963.750000    0.000000   3.598000   \n",
+       "\n",
+       "                          p10X  \n",
+       "datetime                        \n",
+       "2016-11-21 17:00:00  13.519167  \n",
+       "2016-11-21 18:00:00  13.455833  \n",
+       "2016-11-21 19:00:00  13.479667  \n",
+       "2016-11-21 20:00:00  13.521000  \n",
+       "2016-11-21 21:00:00  13.466667  \n",
+       "2016-11-21 22:00:00  13.476333  \n",
+       "2016-11-21 23:00:00  13.331667  \n",
+       "2016-11-22 00:00:00  12.924167  \n",
+       "2016-11-22 01:00:00  12.847833  \n",
+       "2016-11-22 02:00:00  12.811333  \n",
+       "2016-11-22 03:00:00  12.785500  \n",
+       "2016-11-22 04:00:00  12.770000  "
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hr_mean = ps7.xs(3,level='height').resample('1h').mean()\n",
+    "hr_mean"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "T     281.474667\n",
+       "RH     72.718000\n",
+       "P     961.312000\n",
+       "Name: 2016-11-21 23:00:00, dtype: float64"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test = hr_mean.loc['2016-11-21 23:00']\n",
+    "test[['T','RH','P']]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### saturated vapor pressure <font color='green'>- PASSED</font>\n",
+    "https://www.weather.gov/epz/wxcalc_vaporpressure gives $e_s$ = 10.97 mb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10.961379766199544"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fun.e_s(test['T'],model='Bolton1980') # model='Bolton1980' (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10.97058660841359"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fun.e_s(test['T'],model='NWS')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### dewpoint temperature <font color='orange'>- almost identical value</font>\n",
+    "https://www.weather.gov/epz/wxcalc_rh gives $T_d$ = 276.86 K (and wet-bulb temp = 279.22 K)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "276.872367630902"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fun.T_d(test['T'],test['RH'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### mixing ratio <font color='green'>- PASSED</font>\n",
+    "https://www.weather.gov/epz/wxcalc_mixingratio gives $w_s$ = 7.17 g/kg (= 0.00717 kg/kg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.007174171373612398"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fun.w_s(test['T'],test['P'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0070923677376087246"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# assuming p >> e_s, Wallace & Hobbs Eqn. 3.63\n",
+    "fun.epsilon * fun.e_s(test['T']) / test['P']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### virtual temperature <font color='green'>- PASSED</font>\n",
+    "https://www.weather.gov/epz/wxcalc_virtualtemperature (using $T_d$ calculated from https://www.weather.gov/epz/wxcalc_rh) gives $T_v$ = 282.36"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "282.36242470550195"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fun.T_to_Tv(test['T'], p=test['P'], RH=test['RH'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "282.36000747648336"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Td = fun.T_d(test['T'],test['RH'])\n",
+    "fun.T_to_Tv(test['T'], Td=Td, p=test['P'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Add module for converting from measured quantities to QOIs. Right now, this includes a function `helper_functions.T_to_Tv()` that can take a variety of combinations of inputs and convert from measured air temperature into virtual temperature. There are additional functions that perform intermediate calculations that `T_to_Tv()` depends on; these generally come from either Wallace & Hobbs or equations from the NWS, and the source of the equations are noted in the code comments.

You can view `tests/T_to_Tv_tests.ipynb` directly in the browser. This notebook shows how some test data are read (in this case, the PS07 3-m met tower) and how the new functions may be used.

I'm open to adding additional formulations, renaming variable and function names, etc. 