### PR TITLE
Add option for radar profiler reader to parse scan info

### DIFF
--- a/measurements/radar.py
+++ b/measurements/radar.py
@@ -134,7 +134,9 @@ def _read_profiler_data_block(f, read_scan_properties=False,
         # Line 2: station name
         name = f.readline().strip()
     # Line 3: WINDS, version
-    assert(f.readline().split()[0] in expected_datatypes)
+    data_format = f.readline().strip()
+    datatype = data_format.split()[0]
+    assert(datatype in expected_datatypes)
     # Line 4: lat (N), long (W), elevation (m)
     lat,lon,elev = [float(val) for val in f.readline().split()]
     # Line 5: date
@@ -190,6 +192,8 @@ def _read_profiler_data_block(f, read_scan_properties=False,
     # return data and header info if requested
     if read_scan_properties:
         scaninfo = {
+            'station':name,
+            'data_format':data_format,
             # Line 7
             'beam:reqd_records_for_consensus': num_records,
             'beam:tot_num_records': tot_records,

--- a/measurements/radar.py
+++ b/measurements/radar.py
@@ -194,6 +194,10 @@ def _read_profiler_data_block(f, read_scan_properties=False,
         scaninfo = {
             'station':name,
             'data_format':data_format,
+            # Line 6
+            'consensus_avg_time_min':cns_avg_time,
+            'num_beams':num_beams,
+            'num_range_gates':num_ranges,
             # Line 7
             'beam:reqd_records_for_consensus': num_records,
             'beam:tot_num_records': tot_records,

--- a/measurements/radar.py
+++ b/measurements/radar.py
@@ -97,7 +97,7 @@ def _read_profiler_data_block(f,expected_datatypes=['WINDS','RASS']):
     assert(f.readline().split()[0] in expected_datatypes) # Line 3: WINDS, version
     f.readline() # Line 4: lat (N), long (W), elevation (m)
     Y,m,d,H,M,S,_ = f.readline().split() # Line 5: date
-    date_time = pd.to_datetime('20{}{}{} {}{}{}'.format(Y,m,d,H,M,S))
+    datetime = pd.to_datetime('20{}{}{} {}{}{}'.format(Y,m,d,H,M,S))
     f.readline() # Line 6: consensus averaging time
     f.readline() # Line 7: beam info
     f.readline() # Line 8: beam info
@@ -114,5 +114,5 @@ def _read_profiler_data_block(f,expected_datatypes=['WINDS','RASS']):
         block.append(line.split())
         line = f.readline()
     df = pd.DataFrame(data=block,columns=header,dtype=float)
-    df['date_time'] = date_time
+    df['datetime'] = datetime
     return df

--- a/measurements/radar.py
+++ b/measurements/radar.py
@@ -151,24 +151,44 @@ def _read_profiler_data_block(f, read_scan_properties=False,
         num_records = [int(item.split(':')[0]) for item in lineitems[::2]]
         tot_records = [int(item.split(':')[1]) for item in lineitems[::2]]
         cns_window_size = [float(item.strip('()')) for item in lineitems[1::2]]
-        # Line 8: processing info (oblique/vertical pairs)
-        lineitems = [int(val) for val in f.readline().split()]
-        num_coherent_integrations = lineitems[:2]
-        num_spectral_averages = lineitems[2:4]
-        pulse_width = lineitems[4:6] # [ns]
-        inner_pulse_period = lineitems[6:8] # [ms]
-        # Line 9: processing info (oblique/vertical pairs)
-        lineitems = f.readline().split()
-        doppler_value = [float(val) for val in lineitems[:2]] # [m/s]
-        vertical_correction = bool(lineitems[2])
-        delay = [int(val) for val in lineitems[3:5]] # [ns]
-        num_gates = [int(val) for val in lineitems[5:7]]
-        gate_spacing = [int(val) for val in lineitems[7:9]] # [ns]
-        # Line 10: for each beam: azimuth, elevation
-        lineitems = [float(val) for val in f.readline().split()]
-        assert len(lineitems) == 2*num_beams
-        beam_azimuth = lineitems[::2] # [deg]
-        beam_elevation = lineitems[1::2] # [deg]
+        if datatype=='WINDS':
+            # Line 8: processing info (oblique/vertical pairs)
+            lineitems = [int(val) for val in f.readline().split()]
+            num_coherent_integrations = lineitems[:2]
+            num_spectral_averages = lineitems[2:4]
+            pulse_width = lineitems[4:6] # [ns]
+            inner_pulse_period = lineitems[6:8] # [ms]
+            # Line 9: processing info (oblique/vertical pairs)
+            lineitems = f.readline().split()
+            doppler_value = [float(val) for val in lineitems[:2]] # [m/s]
+            vertical_correction = bool(lineitems[2])
+            delay = [int(val) for val in lineitems[3:5]] # [ns]
+            num_gates = [int(val) for val in lineitems[5:7]]
+            gate_spacing = [int(val) for val in lineitems[7:9]] # [ns]
+            # Line 10: for each beam: azimuth, elevation
+            lineitems = [float(val) for val in f.readline().split()]
+            assert len(lineitems) == 2*num_beams
+            beam_azimuth = lineitems[::2] # [deg]
+            beam_elevation = lineitems[1::2] # [deg]
+        elif datatype=='RASS':
+            # Line 8: processing info
+            lineitems = [int(val) for val in f.readline().split()]
+            num_coherent_integrations = lineitems[0]
+            num_spectral_averages = lineitems[1]
+            pulse_width = lineitems[2] # [ns]
+            inner_pulse_period = lineitems[3] # [ms]
+            # Line 9: processing info (oblique/vertical pairs)
+            lineitems = f.readline().split()
+            doppler_value = float(lineitems[0]) # [m/s]
+            vertical_correction = 'n/a'
+            delay = int(lineitems[1]) # [ns]
+            num_gates = int(lineitems[2])
+            gate_spacing = int(lineitems[3]) # [ns]
+            # Line 10: for each beam: azimuth, elevation
+            lineitems = [float(val) for val in f.readline().split()]
+            assert len(lineitems) == 2*num_beams
+            beam_azimuth = lineitems[::2] # [deg]
+            beam_elevation = lineitems[1::2] # [deg]
     else:
         f.readline()
         f.readline()

--- a/measurements/radar.py
+++ b/measurements/radar.py
@@ -49,11 +49,11 @@ def profiler(fname,scans=None,
                 df = _read_profiler_data_block(f)
                 if i in scans:
                     if verbose:
-                        print('Adding mode',i)
+                        print('Adding scan',i)
                     dataframes.append(df)
                 else:
                     if verbose:
-                        print('Skipping mode',i)
+                        print('Skipping scan',i)
         else:
             # read all scans
             i = 0
@@ -64,7 +64,7 @@ def profiler(fname,scans=None,
                     break
                 else:
                     if verbose:
-                        print('Read mode',i)
+                        print('Read scan',i)
                     i += 1
     df = pd.concat(dataframes)
     if na_values is not None:

--- a/measurements/radar.py
+++ b/measurements/radar.py
@@ -46,7 +46,10 @@ def profiler(fname,scans=None,
                 scans_to_read = np.arange(scans)
                 scans = scans_to_read
             for i in scans_to_read:
-                df = _read_profiler_data_block(f)
+                try:
+                    df = _read_profiler_data_block(f)
+                except (IOError,IndexError):
+                    break
                 if i in scans:
                     if verbose:
                         print('Adding scan',i)


### PR DESCRIPTION
Update `measurements.radar.profiler()` to take `read_scan_properties` as a keyword argument. If True or an existing list of scan types (parsed from the profiler data block header) is provided, then each data block that is read from a file will have its scan properties compared against the existing list of scan types and a unique scan-type ID will be assigned. A new "scan_type" column will be created with the scan-type IDs.

Example use case: TTU radar data for 2013-11-08 has 2 different scan types, 2013-11-09 has 3 different scan types. Resulting data will have "scan_type" identifier to distinguish between the different scans.