### PR TITLE
Some updates and cleanup for wrf.utils

### DIFF
--- a/datawriters.py
+++ b/datawriters.py
@@ -10,6 +10,13 @@ standard_datetime_fmt = '%Y-%m-%d %H:%M:%S'
 # for netCDF output
 core_variables = ['Times','u','v','w','wspd','wdir','T','p','theta','RH']
 
+
+# TODO: consider deprecating `wrf.utils.WriteWRFdata2NCDF()`
+def wrf_to_netcdf(lat,lon,datadir,outputfile,dom=1,
+                  prefix='wrfout_d{:02d}_*00'):
+    print('This is a stub')
+
+# TODO: rename `write_to_netCDF` to `dict_to_netcdf`
 def write_to_netCDF(nc_filename, data,
                     ncformat='NETCDF4_CLASSIC',
                     all_variables=False,

--- a/wrf/WriteWRFdata2NCDF.wrf.py
+++ b/wrf/WriteWRFdata2NCDF.wrf.py
@@ -61,8 +61,8 @@ def write_WRF_to_NCDF(lat,lon,datadir,outputfile,dom=1,
         TH2[cc]    = wrfout.variables['TH2'][0,poij,poii]
         swdwn[cc]  = wrfout.variables['SWDOWN'][0,poij,poii]
         # U and V need to be interpolated to cell-center
-        u[cc]      = wrfdict.unstagger2d(wrfout.variables['U'][0,:,poij,poii-1:poii+1],ax=1)[:,0]
-        v[cc]      = wrfdict.unstagger2d(wrfout.variables['V'][0,:,poij-1:poij+1,poii],ax=1)[:,0]
+        u[cc]      = wrfdict.unstagger(wrfout.variables['U'][0,:,poij,poii-1:poii+1],ax=1)[:,0]
+        v[cc]      = wrfdict.unstagger(wrfout.variables['V'][0,:,poij-1:poij+1,poii],ax=1)[:,0]
         # W needs to be unstaggered in the vertical direction
         ws         = wrfout.variables['W'][0,:,poij,poii]
         w[cc]      = (ws[1:] + ws[:-1])*0.5

--- a/wrf/utils.py
+++ b/wrf/utils.py
@@ -264,30 +264,10 @@ def latlon_to_ij(wrfdata,lat,lon):
     jj,ii = np.where(dist==np.min(dist))
     return ii[0],jj[0]
 
-def unstagger2d(var,axis):
-    '''Unstagger 2D variable on given axis'''
-    if axis == 0:
-        varu = (var[:-1,:] + var[1:,:])/2.0
-    if axis == 1:
-        varu = (var[:,:-1] + var[:,1:])/2.0
-    return varu
-
-def unstagger3d(var,axis):
-    '''Unstagger 3D variable on given axis'''
-    if axis == 0:
-        varu = (var[:-1,:,:] + var[1:,:,:])/2.0
-    if axis == 1:
-        varu = (var[:,:-1,:] + var[:,1:,:])/2.0
-    if axis == 2:
-        varu = (var[:,:,:-1] + var[:,:,1:])/2.0
-    return varu
-
-def unstagger4d(var,axis):
-    '''Unstagger 4D variable on given axis'''
-    if axis == 1:
-        varu = (var[:,:-1,:,:] + var[:,1:,:,:])/2.0
-    if axis == 2:
-        varu = (var[:,:,:-1,:] + var[:,:,1:,:])/2.0
-    if axis == 3:
-        varu = (var[:,:,:,:-1] + var[:,:,:,1:])/2.0
-    return varu
+def unstagger(var,axis):
+    '''Unstagger ND variable on given axis'''
+    # left_indx: (:,:,etc.) and replace ":" at ax with ":-1"
+    left_indx = [slice(0,-1) if axi==axis else slice(None) for axi in range(var.ndim)]
+    # right_indx: (:,:,etc.) and replace ":" at ax with "1:"
+    right_indx = [slice(1,None) if axi==axis else slice(None) for axi in range(var.ndim)]
+    return (var[tuple(left_indx)] + var[tuple(right_indx)])/2.0

--- a/wrf/utils.py
+++ b/wrf/utils.py
@@ -64,7 +64,7 @@ def get_avg_height(wrfdata):
         z  = (zs[:,1:] + zs[:,:-1])*0.5
     return z,zs
 
-def get_height(wrfdata):
+def get_xyz_height(wrfdata):
     '''Get heights for all x,y,z'''
     ph  = wrfdata.variables['PH'][0,:,:,:]
     phb = wrfdata.variables['PHB'][0,:,:,:]
@@ -75,6 +75,19 @@ def get_height(wrfdata):
 
     zs  = ((ph+phb)/9.81) - hgt
     z = unstagger(zs,axis=0)
+    return z,zs
+
+def get_xyzt_height(wrfdata):
+    '''Get heights for all x,y,z,t'''
+    ph  = wrfdata.variables['PH'][:]
+    phb = wrfdata.variables['PHB'][:]
+    hgt = wrfdata.variables['HGT'][:]
+    
+    # Convert hgt into 3D array by repeating it nz times along a new axis
+    hgt = np.repeat(hgt[:,np.newaxis, :, :], ph.shape[1], axis=1)
+
+    zs  = ((ph+phb)/9.81) - hgt
+    z = unstagger(zs,axis=1)
     return z,zs
 
 def get_height_at_ind(wrfdata,j,i):

--- a/wrf/utils.py
+++ b/wrf/utils.py
@@ -66,13 +66,15 @@ def get_avg_height(wrfdata):
 
 def get_height(wrfdata):
     '''Get heights for all x,y,z'''
-    nz = _get_dim(wrfdata,'bottom_top')
     ph  = wrfdata.variables['PH'][0,:,:,:]
     phb = wrfdata.variables['PHB'][0,:,:,:]
     hgt = wrfdata.variables['HGT'][0,:,:]
+    
+    # Convert hgt into 3D array by repeating it nz times along a new axis
+    hgt = np.repeat(hgt[np.newaxis, :, :], ph.shape[1], axis=0)
 
     zs  = ((ph+phb)/9.81) - hgt
-    z   = (zs[1:,:,:] + zs[:-1,:,:])*0.5
+    z = unstagger(zs,axis=0)
     return z,zs
 
 def get_height_at_ind(wrfdata,j,i):

--- a/wrf/utils.py
+++ b/wrf/utils.py
@@ -64,21 +64,12 @@ def get_avg_height(wrfdata):
         z  = (zs[:,1:] + zs[:,:-1])*0.5
     return z,zs
 
-def get_xyz_height(wrfdata):
-    '''Get heights for all x,y,z'''
-    ph  = wrfdata.variables['PH'][0,:,:,:]
-    phb = wrfdata.variables['PHB'][0,:,:,:]
-    hgt = wrfdata.variables['HGT'][0,:,:]
-    
-    # Convert hgt into 3D array by repeating it nz times along a new axis
-    hgt = np.repeat(hgt[np.newaxis, :, :], ph.shape[1], axis=0)
-
-    zs  = ((ph+phb)/9.81) - hgt
-    z = unstagger(zs,axis=0)
-    return z,zs
-
-def get_xyzt_height(wrfdata):
-    '''Get heights for all x,y,z,t'''
+def get_height(wrfdata,timevarying=False):
+    '''
+    Get heights for all x,y,z(,t)
+    If timevarying is False, return height for
+    first timestamp only
+    '''
     ph  = wrfdata.variables['PH'][:]
     phb = wrfdata.variables['PHB'][:]
     hgt = wrfdata.variables['HGT'][:]
@@ -88,7 +79,10 @@ def get_xyzt_height(wrfdata):
 
     zs  = ((ph+phb)/9.81) - hgt
     z = unstagger(zs,axis=1)
-    return z,zs
+    if timevarying:
+        return z,zs
+    else:
+        return z[0,...], zs[0,...]
 
 def get_height_at_ind(wrfdata,j,i):
     '''Get model height at a specific j,i'''


### PR DESCRIPTION
- unstagger functions "unstagger2d", "unstagger3d", "unstagger4d" are replaced by one general "unstagger" function that can handle any dimensions
- get_height() had a bug using both 2d and 3d arrays in a calculation. This has been fixed
- a new function get_xyzt_height() has been added to compute the height above ground level for every timestamp, returning a 4d array. The function get_height() has been renamed to get_xyz_height() to reflect that it returns a 3d array.