### PR TITLE
Avoid toggling of grid visibility

### DIFF
--- a/plotting.py
+++ b/plotting.py
@@ -555,7 +555,7 @@ def plot_timehistory_at_height(datasets,
     # Set axis grid
     for axi in axv:
         axi.xaxis.grid(True,which='minor')
-        axi.yaxis.grid()
+        axi.yaxis.grid(True)
     
     # Format time axis
     if isinstance(timevalues, (pd.DatetimeIndex, pd.TimedeltaIndex)):


### PR DESCRIPTION
In `plot_timehistory_at_height`, `ax.yaxis.grid()` was called without any argument, which toggles the grid visibility. Hence, running `plot_timehistory_at_height` twice with fig and ax as argument sets the visibility of the grid lines to off. This behavior has been modified so that grid lines are not switched off when calling the function an even number of times.