### PR TITLE
Generalize dataloaders.read_date_dirs()

### DIFF
--- a/dataloaders.py
+++ b/dataloaders.py
@@ -119,6 +119,9 @@ def read_date_dirs(dpath='.',dir_filter='*',
                    **kwargs):
     """Wrapper around pandas read_csv() or data reader function. 
 
+    If expected_date_format is None, then the datetime is assumed to be
+    in seconds (e.g., a timedelta or simulation time).
+
     Additional readers:
     - measurements/metmast
     - measurements/radar
@@ -138,9 +141,13 @@ def read_date_dirs(dpath='.',dir_filter='*',
         dname = os.path.split(fullpath)[-1]
         if os.path.isdir(fullpath):
             try:
-                collection_date = pd.to_datetime(dname,
-                                                 format=expected_date_format)
+                if expected_date_format is None:
+                    timedelta = float(dname)
+                else:
+                    collection_date = pd.to_datetime(
+                            dname, format=expected_date_format)
             except ValueError:
+                # could not convert to datetime (with the provided format)
                 if verbose:
                     print('Skipping '+dname)
             else:

--- a/dataloaders.py
+++ b/dataloaders.py
@@ -140,13 +140,13 @@ def read_date_dirs(dpath='.',dir_filter='*',file_filter='*',
         dname = os.path.split(fullpath)[-1]
         if os.path.isdir(fullpath):
             try:
+                # check that subdirectories have the expected format
                 if expected_date_format is None:
                     timedelta = float(dname)
                 else:
                     collection_date = pd.to_datetime(
                             dname, format=expected_date_format)
             except ValueError:
-                # could not convert to datetime (with the provided format)
                 if verbose: print('Skipping '+dname)
             else:
                 if verbose: print('Processing '+fullpath)

--- a/dataloaders.py
+++ b/dataloaders.py
@@ -111,10 +111,9 @@ def read_dir(dpath='.',file_filter='*',
     return df
 
 
-def read_date_dirs(dpath='.',dir_filter='*',
+def read_date_dirs(dpath='.',dir_filter='*',file_filter='*',
                    expected_date_format='%Y%m%d',
                    reader=pd.read_csv,
-                   ext='csv',
                    verbose=False,
                    **kwargs):
     """Wrapper around pandas read_csv() or data reader function. 
@@ -152,11 +151,10 @@ def read_date_dirs(dpath='.',dir_filter='*',
                     print('Skipping '+dname)
             else:
                 print('Processing '+fullpath)
-                for fname in sorted(os.listdir(fullpath)):
-                    fpath = os.path.join(fullpath,fname)
-                    if not fname.endswith(ext): continue
+                filelist = glob.glob(os.path.join(fullpath,file_filter))
+                for fpath in sorted(filelist):
                     if verbose:
-                        print('  reading '+fname)
+                        print('  reading '+fpath)
                     try:
                         df = reader(fpath,verbose=verbose,**kwargs)
                     except reader_exceptions as err:

--- a/dataloaders.py
+++ b/dataloaders.py
@@ -147,14 +147,12 @@ def read_date_dirs(dpath='.',dir_filter='*',file_filter='*',
                             dname, format=expected_date_format)
             except ValueError:
                 # could not convert to datetime (with the provided format)
-                if verbose:
-                    print('Skipping '+dname)
+                if verbose: print('Skipping '+dname)
             else:
-                print('Processing '+fullpath)
+                if verbose: print('Processing '+fullpath)
                 filelist = glob.glob(os.path.join(fullpath,file_filter))
                 for fpath in sorted(filelist):
-                    if verbose:
-                        print('  reading '+fpath)
+                    if verbose: print('  reading '+fpath)
                     try:
                         df = reader(fpath,verbose=verbose,**kwargs)
                     except reader_exceptions as err:
@@ -162,9 +160,9 @@ def read_date_dirs(dpath='.',dir_filter='*',file_filter='*',
                     else:
                         dataframes.append(df)
                     Nfiles += 1
-            print('  {} dataframes added'.format(Nfiles))
+            if verbose: print('  {} dataframes added'.format(Nfiles))
     if len(dataframes) == 0:
-        print('No dataframes were read!')
+        print('No dataframes read from',fullpath)
         df = None
     else:
         df = _concat(dataframes)


### PR DESCRIPTION
To handle not only a series of datetime subdirectories, but time directories (e.g.., openfoam simulation times) as well. Add `file_filter` option to provide similar functionality as the other `dataloader.read_*()` functions.