### PR TITLE
Generalize internal coupling

### DIFF
--- a/coupling/sowfa.py
+++ b/coupling/sowfa.py
@@ -31,14 +31,19 @@ class InternalCoupling(object):
             Folder to write files to
         df : pandas.DataFrame
             Data (index should be called datetime)
-        dateref : str
-            Reference datetime, SOWFA uses seconds since this datetime
-        datefrom : str
+        dateref : str, optional
+            Reference datetime, used to construct a pd.DateTimeIndex
+            with SOWFA time 0 corresponding to dateref; if not
+            specified, then the time index will be the simulation time
+            as a pd.TimedeltaIndex
+        datefrom : str, optional
             Start date of the period that will be written out, if None
-            start from the first timestamp in df
-        dateto : str
+            start from the first timestamp in df; only used if dateref
+            is specified
+        dateto : str, optional
             End date of the period that will be written out, if None end
-            with the last timestamp in df
+            with the last timestamp in df; only used if dateref is
+            specified
         """
         
         self.dpath = dpath

--- a/coupling/sowfa.py
+++ b/coupling/sowfa.py
@@ -19,7 +19,7 @@ class InternalCoupling(object):
     def __init__(self,
                  dpath,
                  df,
-                 dateref,
+                 dateref=None,
                  datefrom=None,
                  dateto=None):
         """
@@ -59,11 +59,16 @@ class InternalCoupling(object):
         self.datefrom = datefrom
 
         # calculate time in seconds since reference date
-        dateref = pd.to_datetime(dateref)
-        tdelta = pd.Timedelta(1,unit='s')
-        self.df.reset_index(inplace=True)
-        self.df['t_index'] = (self.df['datetime'] - dateref) / tdelta
-        self.df.set_index('datetime',inplace=True)
+        if dateref is not None:
+            # self.df['datetime'] exists and is a DateTimeIndex
+            dateref = pd.to_datetime(dateref)
+            tdelta = pd.Timedelta(1,unit='s')
+            self.df.reset_index(inplace=True)
+            self.df['t_index'] = (self.df['datetime'] - dateref) / tdelta
+            self.df.set_index('datetime',inplace=True)
+        else:
+            # self.df['t'] exists and is a TimedeltaIndex
+            self.df['t_index'] = self.df.index.total_seconds()
 
     def write_BCs(self,
                   fname,


### PR DESCRIPTION
For cleaner interfacing between SOWFA precursor and finite-domain simulations, e.g., using `sourceHistory_to_drivingForce.ipynb`. 
- Allow `dateref` kwarg to not be specified when initializing the InternalCoupling class--this is not applicable for idealized cases
- Modify `write_timeheight()` so that 
```
timeheight_to_sowfa = InternalCoupling(outputdir,df,dateref)
timeheight_to_sowfa.write_timeheight('forcingTableMomentum',xmom='Fx',ymom='Fy',zmom='Fz')
timeheight_to_sowfa.write_timeheight('forcingTableTemperature',temp='Ft')
```
produces the expected result (with 'forcingTableMomentum' only containing momentum sources, and 'forcingTableTemperature' only containing temperature sources). Previously, all four fields were written into both forcingTable* files.