### PR TITLE
Add landuse submodule

### DIFF
--- a/wrf/landuse.py
+++ b/wrf/landuse.py
@@ -28,6 +28,11 @@ class LandUseTable(dict):
             newdict[season] = pd.DataFrame(index=index, columns=header[1:])
             for idef in range(Ndef):
                 line = f.readline().split(',')
+                if len(line) < len(header):
+                    assert len(line) == len(header)-1, \
+                            'No workaround for reading '+str(line)+'... abort'
+                    # workaround for rows with missing comma after index
+                    line = line[0].split() + line[1:]
                 line[1:-1] = [float(val) for val in line[1:-1]]
                 line[-1] = line[-1].strip().strip("'")
                 idx = int(line[0]) 

--- a/wrf/landuse.py
+++ b/wrf/landuse.py
@@ -60,4 +60,14 @@ class LandUseTable(dict):
             # rename known abbreviations
             newdict[season].rename(columns=abbrev, inplace=True)
             #print(newdict[season])
-        return newdict
+        if Nseason == 1:
+            # return dataframe as is
+            return newdict[season]
+        else:
+            # return dataframe with multiindex
+            for season in newdict.keys():
+                newdict[season]['season'] = season
+            df = pd.concat(newdict.values())
+            df = df.set_index('season', append=True)
+            return df.sort_index()
+

--- a/wrf/landuse.py
+++ b/wrf/landuse.py
@@ -11,7 +11,7 @@ class LandUseTable(dict):
             name = f.readline().strip()
             while not name == '':
                 print('Reading',name)
-                self.__dict__[name] = self._read_def(f)
+                self.__setitem__(name, self._read_def(f))
                 name = f.readline().strip()
                 
     def _read_def(self,f):

--- a/wrf/landuse.py
+++ b/wrf/landuse.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pandas as pd
+
+
+class LandUseTable(dict):
+    """Container for land-use information from WRF"""
+
+    def __init__(self,fpath='LANDUSE.TBL'):
+        """Read specified LANDUSE.TBL file"""
+        with open(fpath,'r') as f:
+            name = f.readline().strip()
+            while not name == '':
+                print('Reading',name)
+                self.__dict__[name] = self._read_def(f)
+                name = f.readline().strip()
+                
+    def _read_def(self,f):
+        headerinfo = f.readline().split(',')
+        Ndef = int(headerinfo[0])
+        Nseason = int(headerinfo[1])
+        header = ['index']
+        header += headerinfo[2].strip().strip("'").split()
+        header += ['description']
+        newdict = dict()
+        index = pd.RangeIndex(1,Ndef+1)
+        for iseason in range(Nseason):
+            season = f.readline().strip()
+            newdict[season] = pd.DataFrame(index=index, columns=header[1:])
+            for idef in range(Ndef):
+                line = f.readline().split(',')
+                line[1:-1] = [float(val) for val in line[1:-1]]
+                line[-1] = line[-1].strip().strip("'")
+                idx = int(line[0]) 
+                newdict[season].loc[idx] = line[1:]
+            #print(newdict[season])
+        return newdict

--- a/wrf/landuse.py
+++ b/wrf/landuse.py
@@ -2,6 +2,23 @@ import numpy as np
 import pandas as pd
 
 
+# names/units in LANDUSE.TBL
+abbrev = {
+    'ALBD': 'albedo',  # [%]
+    'SLMO': 'soil_moisture_availability',  # [-]
+    'SFEM': 'surface_emissivity',  # [-]
+    'SFZ0': 'roughness_length',  # [cm]
+    'THERIN': 'thermal_inertia',  # [100 cal cm^-2 K^-1 s^-1/2] == [4.184e2 J m^-2 K^-1 s^-1/2]?
+    'SCFX': 'snow_cover_effect',  # [-]
+    'SFHC': 'surface_heat_capacity',  # [J m^-3 K^-1]
+}
+
+# standard conversions
+conversions = {
+    'ALBD': 0.01,
+    'SFZ0': 0.01,
+}
+
 class LandUseTable(dict):
     """Container for land-use information from WRF"""
 
@@ -37,5 +54,10 @@ class LandUseTable(dict):
                 line[-1] = line[-1].strip().strip("'")
                 idx = int(line[0]) 
                 newdict[season].loc[idx] = line[1:]
+            # do unit conversions
+            for varn, fac in conversions.items():
+                newdict[season][varn] *= fac
+            # rename known abbreviations
+            newdict[season].rename(columns=abbrev, inplace=True)
             #print(newdict[season])
         return newdict


### PR DESCRIPTION
For collecting information from a LANDUSE.TBL file and putting it into a more usable format. 

Example:
`landuse = LandUseTable('/path/to/WRF/run/LANDUSE.TBL')`
```
Reading OLD
Reading USGS
Reading MODIFIED_IGBP_MODIS_NOAH
Reading SiB
Reading LW12
Reading MODIS
Reading SSIB
```

For single-season definitions, properties are stored in a single-index dataframe:
`print(landuse['LW12'])`
```
	albedo	soil_moisture_availability	surface_emissivity	roughness_length	thermal_inertia	snow_cover_effect	surface_heat_capacity	description
1	0.2	0.3	0.85	0.1	4	2	2.08e+06	Land
2	0.08	1	0.98	0.0001	6	0	9e+25	Water
3	0.7	0.95	0.95	0.05	5	0	9e+25	Snow or Ice
```

For definitions with multiple seasons, properties are stored in a multi-index dataframe:
`print(landuse['USGS'].head())`
```
         albedo soil_moisture_availability surface_emissivity  \
  season                                                        
1 SUMMER   0.15                        0.1               0.88   
  WINTER   0.15                        0.1               0.88   
2 SUMMER   0.17                        0.3              0.985   
  WINTER    0.2                        0.6               0.92   
3 SUMMER   0.18                        0.5              0.985   

         roughness_length thermal_inertia snow_cover_effect  \
  season                                                      
1 SUMMER              0.8               3              1.67   
  WINTER              0.8               3              1.67   
2 SUMMER             0.15               4              2.71   
  WINTER             0.05               4                 2   
3 SUMMER              0.1               4               2.2   

         surface_heat_capacity                     description  
  season                                                        
1 SUMMER              1.89e+06         Urban and Built-Up Land  
  WINTER              1.89e+06         Urban and Built-Up Land  
2 SUMMER               2.5e+06    Dryland Cropland and Pasture  
  WINTER               2.5e+06    Dryland Cropland and Pasture  
3 SUMMER               2.5e+06  Irrigated Cropland and Pasture  
```

Selecting a single definition by multiindex:
`landuse['USGS'].loc[(9,'WINTER')]`
```
albedo                                             0.22
soil_moisture_availability                         0.25
surface_emissivity                                 0.93
roughness_length                                   0.01
thermal_inertia                                       4
snow_cover_effect                                  1.24
surface_heat_capacity                          2.08e+06
description                   Mixed Shrubland/Grassland
Name: (9, WINTER), dtype: object
```
