### PR TITLE
Fix for ConversionError when specifying timelimits

### DIFF
--- a/plotting.py
+++ b/plotting.py
@@ -1656,6 +1656,8 @@ def _format_time_axis(fig,ax,
     Auxiliary function to format time axis
     """
     ax[-1].xaxis_date()
+    if timelimits is not None:
+        timelimits = [pd.to_datetime(tlim) for tlim in timelimits]
     hour_interval = _determine_hourlocator_interval(ax[-1],timelimits)
     if plot_local_time is not False:
         if plot_local_time is True:


### PR DESCRIPTION
Specifying timelimits as a tuple of strings can raise:
```AttributeError: 'numpy.str_' object has no attribute 'toordinal'```
and ultimately:
```ConversionError: Failed to convert value(s) to axis units```
This is traced back to
`ax[-1].set_xlim(timelimits)` in `_format_time_axis`.

Tested with numpy 1.18.1 and matplotlib 3.1.3 (conda-forge)