### PR TITLE
Properly handle staggered tslist profiles in Tower.to_dataframe()

### DIFF
--- a/wrf/utils.py
+++ b/wrf/utils.py
@@ -392,6 +392,19 @@ class Tower():
         interpolation heights are provided, then both staggered and
         unstaggered data will be used for interpolation, and the output
         can be at arbitrary heights.
+
+        Example usage:
+        ```
+        # output with Int64Index
+        mytower = Tower('/path/to/prefix.d03.*')
+        mytower.to_dataframe(start_time='2013-11-08 12:00')
+
+        # output with approximately constant heights
+        mytower = Tower('/path/to/prefix.d03.*')
+        mytower.height = np.mean(mytower.ph, axis=0)  # average over time
+        mytower.height -= mytower.stationz  # make above ground level
+        mytower.to_dataframe(start_time='2013-11-08 12:00')
+        ```
         
         Parameters
         ----------
@@ -459,6 +472,8 @@ class Tower():
             if hasattr(self, height_var):
                 # heights (constant in time) were separately calculated
                 z = getattr(self, height_var)
+                if unstagger:
+                    z = (z[1:] + z[:-1]) / 2
                 assert (len(z.shape) == 1) and (len(z) == nz), \
                         'tower '+height_var+' attribute should correspond to fixed height levels'
             else:

--- a/wrf/utils.py
+++ b/wrf/utils.py
@@ -410,9 +410,7 @@ class Tower():
         # combine (and interpolate) time-height data
         # - note 1: self.[varn].shape == self.height.shape == (self.nt, self.nz)
         # - note 2: arraydata.shape == (self.nt, len(varns)*self.nz)
-        arraydata = np.concatenate(
-            [ getattr(self,varn) for varn in varns ], axis=1
-        )
+        datadict = { varn: getattr(self,varn).ravel() for varn in varns }
         if heights is None:
             if hasattr(self, height_var):
                 # heights (constant in time) were separately calculated
@@ -422,8 +420,8 @@ class Tower():
             else:
                 # heights will be an integer index
                 z = np.arange(self.nz)
-            columns = pd.MultiIndex.from_product([varns,z],names=[None,'height'])
-            df = pd.DataFrame(data=arraydata,index=times,columns=columns).stack()
+            idx = pd.MultiIndex.from_product([times,z],names=['datetime','height'])
+            df = pd.DataFrame(data=datadict,index=idx)
         else:
             from scipy.interpolate import interp1d
             z = np.array(heights)

--- a/wrf/utils.py
+++ b/wrf/utils.py
@@ -398,6 +398,7 @@ class Tower():
         start_time = pd.to_datetime(start_time)
         if time_step is None:
             times = start_time + pd.to_timedelta(self.time, unit=time_unit)
+            times = times.round(freq='1s')
             times.name = 'datetime'
         else:
             timestep = pd.to_timedelta(time_step, unit='s')

--- a/wrf/utils.py
+++ b/wrf/utils.py
@@ -369,7 +369,10 @@ class Tower():
                     datadict[varn] = tsdata[:,:-1].ravel()
                 else:
                     # other quantities already unstaggered
-                    assert np.all(tsdata[:,-1] == 0), 'Unexpected nonzero value for '+varn
+                    if not varn == 'ww':
+                        # don't throw a warning if w is already unstaggered by the code
+                        # last value is (w(model top) + 0.0)/2.0
+                        assert np.all(tsdata[:,-1] == 0), 'Unexpected nonzero value for '+varn
                     # drop the trailing 0 for already unstaggered quantities
                     datadict[varn] = tsdata[:,:-1].ravel()
             else:
@@ -543,16 +546,16 @@ class Tower():
                     tsdata = getattr(self,varn)
                     if varn == 'th':
                         # theta is a special case
-                        tsdata -= 300
+                        assert np.all(tsdata[:,-1] == 300)
+                    elif not varn == 'ww':
+                        # if w has already been destaggered by wrf
+                        assert np.all(tsdata[:,-1] == 0)
                     for itime in range(self.nt):
-                        assert np.all(tsdata[itime,-1] == 0)
                         interpfun = interp1d(zt_unstag[itime,:],
                                              tsdata[itime,:-1],
                                              bounds_error=False,
                                              fill_value='extrapolate')
                         newdata[itime,:] = interpfun(z)
-                    if varn == 'th':
-                        newdata += 300
                     datadict[varn] = newdata.ravel()
                 for varn in varns_stag:
                     newdata = np.empty((self.nt, len(z)))

--- a/wrf/utils.py
+++ b/wrf/utils.py
@@ -577,7 +577,10 @@ class Tower():
                   exclude=['ts'],
                   structure='ordered'):
         
-        df = self.to_dataframe(start_time,time_unit,time_step,heights,height_var,exclude)
+        df = self.to_dataframe(start_time,
+                time_unit=time_unit, time_step=time_step,
+                heights=heights, height_var=height_var, agl=agl,
+                exclude=exclude)
         if structure == 'ordered':
             ds = df.to_xarray().assign_coords(i=self.loci).assign_coords(j=self.locj).expand_dims(['j','i'],axis=[2,3])
             ds = ds.reset_index(['height'], drop = True).rename_dims({'height':'k'})


### PR DESCRIPTION
Add new `unstagger` kwarg (True by default) that also depends on an additional optional `staggered_vars` option. This affects calls to `Tower.to_dataframe()` for which no interpolation to specified heights is requested. For height interpolation, staggering is handled by separately interpolating staggered and unstaggered data. 

A slight performance enhancement should also have been achieved. Dataframes are now created by a data dictionary and time-height multi-index. Previously, this was accomplished by supplying 2-D data arrays, creating the dataframe in a wide (unstacked) format (time index and with multiindex columns), and then doing a stack operation. Not sure why this was a good idea at the time...