### PR TITLE
Put 'datetime' first in list of time dimension_names

### DIFF
--- a/plotting.py
+++ b/plotting.py
@@ -75,7 +75,7 @@ standard_spectrumlabels = spectrumlabels_default_units
 
 # Supported dimensions and associated names
 dimension_names = {
-    'time':      ['time','Time','datetime'],
+    'time':      ['datetime','time','Time'],
     'height':    ['height','heights','z'],
     'frequency': ['frequency','f',]
 }


### PR DESCRIPTION
In the situation where a dataframe to be plotted has both "datetime" and "Time" indices (e.g., corresponding to timestamps and simulation time, respectively), the time index is expected to be "datetime". Here we update `dimension_names['time']` to have "datetime" come first.