### PR TITLE
Improve TaylorDiagram plotting class

### DIFF
--- a/plotting.py
+++ b/plotting.py
@@ -1995,6 +1995,9 @@ class TaylorDiagram(object):
         Add sample (*stddev*, *corrcoeff*) to the Taylor
         diagram. *args* and *kwargs* are directly propagated to the
         `Figure.plot` command.
+
+        `norm` may be specified to override the default normalization
+        value if TaylorDiagram was initialized with normalize=True
         """
         if (corrcoef < 0) and (self.tmax == np.pi/2):
             print('Note: ({:g},{:g}) not shown for R2 < 0, set extend=True'.format(stddev,corrcoef))
@@ -2003,6 +2006,8 @@ class TaylorDiagram(object):
         if self.normalize:
             if norm is None:
                 norm = self.refstd
+            elif norm is False:
+                norm = 1
             stddev /= norm
 
         l, = self.ax.plot(np.arccos(corrcoef), stddev,

--- a/plotting.py
+++ b/plotting.py
@@ -2003,21 +2003,25 @@ class TaylorDiagram(object):
 
         return contours
 
-    def set_xlabel(self, label):
+    def set_xlabel(self, label, fontsize=None):
         """
         Set the label for the standard deviation axis
         """
         self._ax.axis["left"].label.set_text(label)
+        if fontsize is not None:
+            self._ax.axis["left"].label.set_fontsize(fontsize)
 
-    def set_alabel(self, label):
+    def set_alabel(self, label, fontsize=None):
         """
         Set the label for the azimuthal axis
         """
         self._ax.axis["top"].label.set_text(label)
+        if fontsize is not None:
+            self._ax.axis["top"].label.set_fontsize(fontsize)
 
-    def set_title(self, label):
+    def set_title(self, label, **kwargs):
         """
         Set the title for the axes
         """
-        self._ax.set_title(label)
+        self._ax.set_title(label, **kwargs)
 

--- a/plotting.py
+++ b/plotting.py
@@ -1980,7 +1980,17 @@ class TaylorDiagram(object):
         # Collect sample points for latter use (e.g. legend)
         self.samplePoints = [l]
 
-    def add_sample(self, stddev, corrcoef, *args, **kwargs):
+    def set_ref(self, refstd):
+        """
+        Update the reference standard deviation value
+
+        Useful for cases in which datasets with different reference
+        values (e.g., originating from different reference heights)
+        are to be overlaid on the same diagram.
+        """
+        self.refstd = refstd
+
+    def add_sample(self, stddev, corrcoef, norm=None, *args, **kwargs):
         """
         Add sample (*stddev*, *corrcoeff*) to the Taylor
         diagram. *args* and *kwargs* are directly propagated to the
@@ -1991,7 +2001,9 @@ class TaylorDiagram(object):
             return None
 
         if self.normalize:
-            stddev /= self.refstd
+            if norm is None:
+                norm = self.refstd
+            stddev /= norm
 
         l, = self.ax.plot(np.arccos(corrcoef), stddev,
                           *args, **kwargs)  # (theta, radius)

--- a/plotting.py
+++ b/plotting.py
@@ -1833,6 +1833,7 @@ class TaylorDiagram(object):
 
     def __init__(self, refstd,
                  fig=None, rect=111, label='_', srange=(0, 1.5), extend=False,
+                 corrticks=[0, 0.2, 0.4, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 1],
                  stdevticks=None,
                  labelsize=None):
         """
@@ -1853,6 +1854,8 @@ class TaylorDiagram(object):
             Stdev axis limits, in units of *refstd*
         extend: bool, optional
             Extend diagram to negative correlations
+        corrticks: list-like, optional
+            Specify ticks positions on azimuthal correlation axis
         stdevticks: int or list-like, optional
             Specify stdev axis grid locator based on MaxNLocator (with
             integer input) or FixedLocator (with list-like input)
@@ -1869,7 +1872,7 @@ class TaylorDiagram(object):
         tr = PolarAxes.PolarTransform()
 
         # Correlation labels
-        rlocs = np.array([0, 0.2, 0.4, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 1])
+        rlocs = np.array(corrticks)
         if extend:
             # Diagram extended to negative correlations
             self.tmax = np.pi

--- a/plotting.py
+++ b/plotting.py
@@ -1960,6 +1960,9 @@ class TaylorDiagram(object):
         diagram. *args* and *kwargs* are directly propagated to the
         `Figure.plot` command.
         """
+        if (corrcoef < 0) and (self.tmax == np.pi/2):
+            print('Note: ({:g},{:g}) not shown for R2 < 0, set extend=True'.format(stddev,corrcoef))
+            return None
 
         l, = self.ax.plot(np.arccos(corrcoef), stddev,
                           *args, **kwargs)  # (theta, radius)

--- a/plotting.py
+++ b/plotting.py
@@ -1833,6 +1833,7 @@ class TaylorDiagram(object):
 
     def __init__(self, refstd,
                  fig=None, rect=111, label='_', srange=(0, 1.5), extend=False,
+                 normalize=False,
                  corrticks=[0, 0.2, 0.4, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 1],
                  minorcorrticks=None,
                  stdevticks=None,
@@ -1855,6 +1856,8 @@ class TaylorDiagram(object):
             Stdev axis limits, in units of *refstd*
         extend: bool, optional
             Extend diagram to negative correlations
+        normalize: bool, optional
+            Normalize stdev axis by `refstd`
         corrticks: list-like, optional
             Specify ticks positions on azimuthal correlation axis
         minorcorrticks: list-like, optional
@@ -1871,6 +1874,7 @@ class TaylorDiagram(object):
         from mpl_toolkits.axisartist import grid_finder
 
         self.refstd = refstd            # Reference standard deviation
+        self.normalize = normalize
 
         tr = PolarAxes.PolarTransform()
 
@@ -1904,8 +1908,10 @@ class TaylorDiagram(object):
             gl2 = None
 
         # Standard deviation axis extent (in units of reference stddev)
-        self.smin = srange[0] * self.refstd
-        self.smax = srange[1] * self.refstd
+        self.smin, self.smax = srange
+        if not normalize:
+            self.smin *= self.refstd
+            self.smax *= self.refstd
 
         ghelper = floating_axes.GridHelperCurveLinear(
             tr,
@@ -1932,7 +1938,10 @@ class TaylorDiagram(object):
 
         # - "x" axis
         ax.axis["left"].set_axis_direction("bottom")
-        ax.axis["left"].label.set_text("Standard deviation")
+        if normalize:
+            ax.axis["left"].label.set_text("Normalized standard deviation")
+        else:
+            ax.axis["left"].label.set_text("Standard deviation")
 
         # - "y" axis
         ax.axis["right"].set_axis_direction("top")    # "Y-axis"
@@ -1959,10 +1968,13 @@ class TaylorDiagram(object):
         self.ax = ax.get_aux_axes(tr)   # Polar coordinates
 
         # Add reference point and stddev contour
-        l, = self.ax.plot([0], self.refstd, 'k*',
-                          ls='', ms=10, label=label)
         t = np.linspace(0, self.tmax)
-        r = np.zeros_like(t) + self.refstd
+        r = np.ones_like(t)
+        if self.normalize:
+            l, = self.ax.plot([0], [1], 'k*', ls='', ms=10, label=label)
+        else:
+            l, = self.ax.plot([0], self.refstd, 'k*', ls='', ms=10, label=label)
+            r *= refstd
         self.ax.plot(t, r, 'k--', label='_')
 
         # Collect sample points for latter use (e.g. legend)
@@ -1978,6 +1990,9 @@ class TaylorDiagram(object):
             print('Note: ({:g},{:g}) not shown for R2 < 0, set extend=True'.format(stddev,corrcoef))
             return None
 
+        if self.normalize:
+            stddev /= self.refstd
+
         l, = self.ax.plot(np.arccos(corrcoef), stddev,
                           *args, **kwargs)  # (theta, radius)
         self.samplePoints.append(l)
@@ -1989,7 +2004,7 @@ class TaylorDiagram(object):
 
         self._ax.grid(*args, **kwargs)
 
-    def add_contours(self, levels=5, **kwargs):
+    def add_contours(self, levels=5, scale=1.0, **kwargs):
         """
         Add constant centered RMS difference contours, defined by *levels*.
         """
@@ -1997,7 +2012,13 @@ class TaylorDiagram(object):
         rs, ts = np.meshgrid(np.linspace(self.smin, self.smax),
                              np.linspace(0, self.tmax))
         # Compute centered RMS difference
-        rms = np.sqrt(self.refstd**2 + rs**2 - 2*self.refstd*rs*np.cos(ts))
+        if self.normalize:
+            # - normalized refstd == 1
+            # - rs values were previously normalized in __init__
+            # - premultiply with (scale==refstd) to get correct rms diff
+            rms = scale * np.sqrt(1 + rs**2 - 2*rs*np.cos(ts))
+        else:
+            rms = np.sqrt(self.refstd**2 + rs**2 - 2*self.refstd*rs*np.cos(ts))
 
         contours = self.ax.contour(ts, rs, rms, levels, **kwargs)
 

--- a/plotting.py
+++ b/plotting.py
@@ -2014,3 +2014,10 @@ class TaylorDiagram(object):
         Set the label for the azimuthal axis
         """
         self._ax.axis["top"].label.set_text(label)
+
+    def set_title(self, label):
+        """
+        Set the title for the axes
+        """
+        self._ax.set_title(label)
+

--- a/plotting.py
+++ b/plotting.py
@@ -1834,6 +1834,7 @@ class TaylorDiagram(object):
     def __init__(self, refstd,
                  fig=None, rect=111, label='_', srange=(0, 1.5), extend=False,
                  corrticks=[0, 0.2, 0.4, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 1],
+                 minorcorrticks=None,
                  stdevticks=None,
                  labelsize=None):
         """
@@ -1856,6 +1857,8 @@ class TaylorDiagram(object):
             Extend diagram to negative correlations
         corrticks: list-like, optional
             Specify ticks positions on azimuthal correlation axis
+        minorcorrticks: list-like, optional
+            Specify minor tick positions on azimuthal correlation axis
         stdevticks: int or list-like, optional
             Specify stdev axis grid locator based on MaxNLocator (with
             integer input) or FixedLocator (with list-like input)
@@ -1872,7 +1875,10 @@ class TaylorDiagram(object):
         tr = PolarAxes.PolarTransform()
 
         # Correlation labels
-        rlocs = np.array(corrticks)
+        if minorcorrticks is None:
+            rlocs = np.array(corrticks)
+        else:
+            rlocs = np.array(sorted(list(corrticks) + list(minorcorrticks)))
         if extend:
             # Diagram extended to negative correlations
             self.tmax = np.pi
@@ -1880,9 +1886,14 @@ class TaylorDiagram(object):
         else:
             # Diagram limited to positive correlations
             self.tmax = np.pi/2
+        if minorcorrticks is None:
+            rlocstrs = [str(rloc) for rloc in rlocs]
+        else:
+            rlocstrs = [str(rloc) if abs(rloc) in corrticks else ''
+                        for rloc in rlocs]
         tlocs = np.arccos(rlocs)        # Conversion to polar angles
         gl1 = grid_finder.FixedLocator(tlocs)    # Positions
-        tf1 = grid_finder.DictFormatter(dict(zip(tlocs, map(str, rlocs))))
+        tf1 = grid_finder.DictFormatter(dict(zip(tlocs, rlocstrs)))
 
         # Stdev labels
         if isinstance(stdevticks, int):


### PR DESCRIPTION
Example usage for overlaying multiple model/reference data levels on the same plot:
```python
fig = plt.figure(figsize=(11,8))
td = TaylorDiagram(1.0, label='lidar', fig=fig,
                   srange=(0,1.6), extend=False,
                   normalize=True,
                   corrticks=[0,.1,.2,.3,.4,.5,.6,.7,.8,.9,.95,.99],
                   #minorcorrticks=np.arange(0.05,0.9,0.1),
                   stdevticks=np.arange(0.2,1.6,0.2),
                   labelsize='x-large')

selected_tower = dict(nx=1, ny=1)

stats = {}
pthandles = {}
for case in cases.keys():
    reanalysis,starttime = case
    descstr = starttime.strftime('{:s} init %Y%m%d %HZ'.format(reanalysis))
    
    stats[case] = pd.DataFrame(index=refheights, columns=['std_norm','R2'], dtype=float)    
    for z in refheights:
        ref_wspd = ref['wspd'].xs(z, level='height')
        refstdev = ref_wspd.std()
        model_wspd = model[case]['wspd'].isel(**selected_tower).sel(height=z).values
        stdev = model_wspd.std()
        r2,_ = pearsonr(model_wspd, ref_wspd)
        stats[case].loc[z,'std_norm'] = stdev / refstdev
        stats[case].loc[z,'R2'] = r2
        #print(descstr,z,stdev,r2)
        color = colors[reanalysis]
        marker = markers[starttime]
        td.set_ref(refstdev)
        td.add_sample(stdev, r2,
                      marker=marker, ms=6, ls='',
                      mfc=color, mec=color, alpha=0.3,
                      label=None, #label=descstr,
                     )

    stats[case]['angle'] = np.arccos(stats[case]['R2'])
    mean = stats[case].mean(axis=0)
    pt = td.add_sample(
        #mean['std_norm'], mean['R2'],
        # Note: add_sample(std,R2) plots polar coords (r,theta), where r==std and theta==arccos(R2)
        mean['std_norm'], np.cos(mean['angle']),
        norm=False, # don't normalize this point
        marker=marker, ms=12, ls='',
        mfc=color, mec=color, alpha=0.9,
        label=descstr,
    )
    pthandles[descstr] = pt
        
# Add grid
td.add_grid()

# Add RMS contours, and label them
contours = td.add_contours(levels=20, colors='0.5')
plt.clabel(contours, inline=1, fontsize=10, fmt='%.2f')

# Add a figure legend
# fig.legend(td.samplePoints,
#            [ p.get_label() for p in td.samplePoints ],
#            numpoints=1, prop=dict(size='medium'), loc='upper right')
fig.legend(pthandles.values(),
           pthandles.keys(),
           numpoints=1, fontsize='medium', loc='upper right')

fig.savefig('figures/taylor_diagram_norm_allheights.png',bbox_inches='tight')
```
Note: this example can be rewritten with changing heights as the outer loop, which avoids calling `td.set_ref()` for every point.