### PR TITLE
Fix gridlines

### DIFF
--- a/plotting.py
+++ b/plotting.py
@@ -595,7 +595,7 @@ def plot_timehistory_at_height(datasets,
    
     # Set axis grid
     for axi in axv:
-        axi.xaxis.grid(True,which='minor')
+        axi.xaxis.grid(True,which='both')
         axi.yaxis.grid(True)
     
     # Format time axis

--- a/plotting.py
+++ b/plotting.py
@@ -1758,12 +1758,13 @@ def _format_time_axis(fig,ax,
         tstr = 'UTC time'
         ax2 = None
 
-    # Make sure both major and minor axis labels are visible when they are at
-    # the same time
-    ax[-1].xaxis.remove_overlapping_locs = False
-
-    # Set time label
+    # Now, update all axes
     for axi in ax:
+        # Make sure both major and minor axis labels are visible when they are
+        # at the same time
+        axi.xaxis.remove_overlapping_locs = False
+
+        # Set time label
         axi.set_xlabel(tstr)
 
     return ax2


### PR DESCRIPTION
Address an issue that occasionally arises in which a subplot from `plot_timehistory_at_height` will having missing gridlines where major and minor xaxis lines are coincident.