### PR TITLE
Allow latest versions of packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,10 +35,10 @@ VERSION = '0.1.1'
 REQUIRED = [
     # core
     'matplotlib>=3',
-    'numpy==1.18.1',
-    'scipy==1.4.1',
-    'pandas==1.0.1',
-    'xarray==0.15.0',
+    'numpy>=1.18.1',
+    'scipy>=1.4.1',
+    'pandas>=1.0.1',
+    'xarray>=0.15.0',
     'netcdf4>=1.5.1',
     'dask>=2.10.1',
     'utm>=0.5.0',


### PR DESCRIPTION
While working with @phawbeck, we encountered some strange errors with the `pickle` module that were resolved by updating to the latest `pandas` version. 