### PR TITLE
Update wrfout series reader

### DIFF
--- a/mmctools/wrf/utils.py
+++ b/mmctools/wrf/utils.py
@@ -1225,6 +1225,10 @@ def wrfout_seriesReader(wrf_path,wrf_file_filter,specified_heights=None,
     ds_subset['p'] = xr.DataArray(ds['P']+ds['PB'], dims=dim_keys)
     ds_subset['theta'] = xr.DataArray(ds[temp_var]+TH0, dims=dim_keys)
 
+    # clip vertical extent if requested
+    if hlim_ind is not None:
+        ds_subset = ds_subset.isel(bottom_top=slice(0, hlim_ind))
+
     # optionally, interpolate to static heights	
     if specified_heights is not None:	
         zarr = ds_subset['z']	
@@ -1260,13 +1264,7 @@ def wrfout_seriesReader(wrf_path,wrf_file_filter,specified_heights=None,
             dims_dict.pop(olddim)
     ds_subset = ds_subset.rename_dims(dims_dict)
     
-    # Change by WHL to eliminate vertical info far from the surface to prevent memory crash                                       
-    try:
-        ds_subset2 = ds_subset.isel( nz = slice(0, hlim_ind) )
-        return ds_subset2
-    except:
-        # if hlim_ind = None, default code execution
-        return ds_subset
+    return ds_subset
 
 
 def write_tslist_file(fname,lat=None,lon=None,i=None,j=None,twr_names=None,twr_abbr=None):

--- a/mmctools/wrf/utils.py
+++ b/mmctools/wrf/utils.py
@@ -868,7 +868,7 @@ def extract_column_from_wrfdata(fpath, coords,
             continue
             
         # 4D field specific processing
-        if field is 'T':
+        if field == 'T':
             # Add T0, set surface plane to TSK
             WRFdata[field] += T0
             WRFdata[field] = add_surface_plane(WRFdata[field],plane=WRFdata['TSK'])

--- a/mmctools/wrf/utils.py
+++ b/mmctools/wrf/utils.py
@@ -1269,9 +1269,7 @@ def wrfout_seriesReader(wrf_path,wrf_file_filter,specified_heights=None,
             if (var == 'z') or ('bottom_top' not in ds_subset[var].dims):
                 continue
             print('Interpolating',var)	
-            interpolated = wrfpy.interplevel(ds_subset[var], zarr, specified_heights)	
-            ds_subset[var] = interpolated #.expand_dims('Time', axis=0)	
-            #print(ds_subset[var])
+            ds_subset[var] = wrfpy.interpz3d(ds_subset[var], zarr, specified_heights)	
         ds_subset = ds_subset.drop_dims('bottom_top').rename({'level':'z'})	
         dim_keys[1] = 'z'	
         dims_dict.pop('bottom_top')

--- a/mmctools/wrf/utils.py
+++ b/mmctools/wrf/utils.py
@@ -1140,7 +1140,7 @@ def tsout_seriesReader(fdir, restarts, simulation_start_time, domain_of_interest
 
 
 def wrfout_seriesReader(wrf_path,wrf_file_filter,specified_heights=None,
-                        hlim_ind=None):
+                        hlim_ind=None,temp_var='THM'):
     """
     Construct an a2e-mmc standard, xarrays-based, data structure from a
     series of 3-dimensional WRF output files
@@ -1157,15 +1157,18 @@ def wrfout_seriesReader(wrf_path,wrf_file_filter,specified_heights=None,
         output files.
     specified_heights : list-like, optional	
         If not None, then a list of static heights to which all data
-        variables should be	interpolated. Note that this significantly
+        variables should be interpolated. Note that this significantly
         increases the data read time.
     hlim_ind : int, index
-        If not none, then the DataArray ds_subset is further subset by vertical dimension,
-        keeping vertical layers 0:hlim_ind.
-        This is meant to be used to speed up execution of the code or prevent a memory error
-        where the specified_heights argument is not well suited
-        (i.e., want a range of non-interpolated heights), and you only care about
-        data that are below a certain vertical index.
+        If not none, then the DataArray ds_subset is further subset by
+        vertical dimension, keeping vertical layers 0:hlim_ind. This is
+        meant to be used to speed up execution of the code or prevent a
+        memory error where the specified_heights argument is not well
+        suited (i.e., want a range of non-interpolated heights), and you
+        only care about data that are below a certain vertical index.
+    temp_var : str, optional
+        Name of moist potential temperature variable, e.g., 'THM' for
+        standard WRF output or 'T' MMC auxiliary output
     """
     import wrf as wrfpy
     TH0 = 300.0 #WRF convention base-state theta = 300.0 K
@@ -1212,7 +1215,7 @@ def wrfout_seriesReader(wrf_path,wrf_file_filter,specified_heights=None,
 
     print('Extracting data variables, p,theta...')
     ds_subset['p'] = xr.DataArray(ds['P']+ds['PB'], dims=dim_keys)
-    ds_subset['theta'] = xr.DataArray(ds['THM']+TH0, dims=dim_keys)
+    ds_subset['theta'] = xr.DataArray(ds[temp_var]+TH0, dims=dim_keys)
 
     # optionally, interpolate to static heights	
     if specified_heights is not None:	


### PR DESCRIPTION
- add `temp_var` option to handle auxiliary output for MMC that has a different variable name for moist potential temperature (`T` instead of `THM`)
- add `use_dimension_coords` option to facilitate and expedite xarray operations
- clean up vertical clipping code

Tested on auxout data with/without `specified_heights`, `hlim_indx`, and `use_dimension_coords`. 