### PR TITLE
Add functions for TRI and VRM

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -14,3 +14,4 @@ dependencies:
   - f90nml=1.1.2
   - elevation=1.0.6
   - rasterio=1.0.25
+  - richdem=0.3.4

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,8 @@ EXTRAS = {
     'wrf-python': ['wrf-python>=1.3.2'],
     # Coupling with terrain (mmctools.coupling.terrain)
     'terrain': ['elevation==1.0.6', 'rasterio==1.0.25'],
-}
+    # For calculating vector ruggedness 
+    'richdem': ['richdem==0.3.4']
 
 # The rest you shouldn't have to touch too much :)
 # ------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ EXTRAS = {
     'terrain': ['elevation==1.0.6', 'rasterio==1.0.25'],
     # For calculating vector ruggedness 
     'richdem': ['richdem==0.3.4']
+}
 
 # The rest you shouldn't have to touch too much :)
 # ------------------------------------------------


### PR DESCRIPTION
Functions for Terrain Ruggedness Index (TRI) and Vector Ruggedness
Measure (VRM) accept lists, arrays, and xr.Dataset and DataArray.
Returned are arrays with the respective TRI or VRM values. Both of
these calculations rely on a height array and a specified window.