### PR TITLE
Fix for xr.Datasets in calc_spectra function

### DIFF
--- a/mmctools/helper_functions.py
+++ b/mmctools/helper_functions.py
@@ -1233,10 +1233,7 @@ def calc_spectra(data,
     
     for ll,lvl in enumerate(level):
         if lvl is not None:
-            if level_dim in list(data.coords.keys()):
-                spec_dat_lvl = data.sel({level_dim:lvl},method='nearest')
-            else:
-                spec_dat_lvl = data.sel({level_dim:lvl})
+            spec_dat_lvl = data.sel({level_dim:lvl},method='nearest')
             lvl = spec_dat_lvl[level_dim].data
         else:
             spec_dat_lvl = data.copy()


### PR DESCRIPTION
Some issues come up in xr.Datasets when not all dimensions have coordinates, and when coordinates are not dimensions. This makes it so every dimension has an associated coord, and any leftover coords become variables.