### PR TITLE
Fix time coord bug for BoundaryCoupling

### DIFF
--- a/mmctools/coupling/sowfa.py
+++ b/mmctools/coupling/sowfa.py
@@ -376,7 +376,7 @@ class BoundaryCoupling(object):
         else:
             dateref = pd.to_datetime(dateref)
         tidx = (self.ds['datetime'] - dateref.to_datetime64()) / np.timedelta64(1,'s')
-        self.ds = self.ds.assign_coords(t_index=('datetime',tidx))
+        self.ds = self.ds.assign_coords(t_index=('datetime',tidx.values))
 
     def _check_xarray_dataset(self,
                               expected_dims=['datetime','height','x','y']):
@@ -408,8 +408,6 @@ class BoundaryCoupling(object):
     
         Usage
         =====
-        patchname : str
-            Name of patch subdirectory
         fields : dict
             Key-value pairs with keys corresponding to the OpenFOAM
             field name, values corresponding to dataset data variables;


### PR DESCRIPTION
Successfully tested `mmctools.coupling.sowfa.BoundaryCoupling`.

Example snippet
```
# given ds with defined _dimension coordinates_ datetime, height, y, z...
yzplane = ds.isel(y=100)
bd = BoundaryCoupling('bndrydata',yzplane,'west',dateref='2000-01-01')
bd.write({'U':'U','V':'V','W':'W','T':'T'}, gzip=True)
```